### PR TITLE
Add gg_lens_table functionality and tests

### DIFF
--- a/sim_pipeline/gg_lens_table.py
+++ b/sim_pipeline/gg_lens_table.py
@@ -1,0 +1,55 @@
+from astropy.table import Table
+from sim_pipeline.Pipelines.skypy_pipeline import SkyPyPipeline
+from sim_pipeline.gg_lens import GGLens, theta_e_when_source_infinity
+import numpy as np
+
+
+
+def create_table(gg_lens_population, parameters=['einstein_radius', 'ellipticity', 'velocity_dispersion', 'stellar_mass', 'magnitude', 'source_redshift', 'lens_redshift']):
+    """
+    Creates an astropy table for a given gg_lens population.
+
+    :param gg_lens_population: List of GGLens instances.
+    :type gg_lens_population: list
+    :param parameters: List of parameters to extract from the population.
+    :type parameters: list
+    :return: Astropy table with lens properties.
+    :rtype: `~astropy.table.Table`
+    """
+
+    # Dictionary of methods to call for each parameter
+    param_methods = {
+        'einstein_radius': 'get_einstein_radius',
+        'ellipticity': 'get_ellipticity',
+        'velocity_dispersion': 'get_velocity_dispersion',
+        'stellar_mass': 'get_stellar_mass',
+        'magnitude': 'get_magnitude',
+        'source_redshift': 'get_source_redshift',
+        'lens_redshift': 'get_lens_redshift'
+    }
+
+    data = {param: [] for param in parameters}
+
+    # Single loop through the gg_lens_population
+    for lens in gg_lens_population:
+        for param in parameters:
+            method = getattr(lens, param_methods[param])
+            data[param].append(method())
+
+    # Construct table from the extracted data
+    t = Table(names=parameters)
+    for param in parameters:
+        t[param] = data[param]
+
+    return t
+
+gg_lens_population_obj = GGLens
+kwargs_lens_cut = {}
+# Drawing the gg lens population
+pop = gg_lens_population_obj.draw_population(kwargs_lens_cut)
+
+# Create the Astropy table with desired parameters
+desired_parameters = ['einstein_radius', 'ellipticity', 'source_redshift']
+table = create_table(pop, parameters=desired_parameters)
+# table.write('output_file.csv', format='csv')
+print(table)

--- a/sim_pipeline/gg_lens_table.py
+++ b/sim_pipeline/gg_lens_table.py
@@ -4,10 +4,19 @@ from sim_pipeline.gg_lens import GGLens, theta_e_when_source_infinity
 import numpy as np
 
 
-
-def create_table(gg_lens_population, parameters=['einstein_radius', 'ellipticity', 'velocity_dispersion', 'stellar_mass', 'magnitude', 'source_redshift', 'lens_redshift']):
-    """
-    Creates an astropy table for a given gg_lens population.
+def create_table(
+    gg_lens_population,
+    parameters=[
+        "einstein_radius",
+        "ellipticity",
+        "velocity_dispersion",
+        "stellar_mass",
+        "magnitude",
+        "source_redshift",
+        "lens_redshift",
+    ],
+):
+    """Creates an astropy table for a given gg_lens population.
 
     :param gg_lens_population: List of GGLens instances.
     :type gg_lens_population: list
@@ -19,13 +28,13 @@ def create_table(gg_lens_population, parameters=['einstein_radius', 'ellipticity
 
     # Dictionary of methods to call for each parameter
     param_methods = {
-        'einstein_radius': 'get_einstein_radius',
-        'ellipticity': 'get_ellipticity',
-        'velocity_dispersion': 'get_velocity_dispersion',
-        'stellar_mass': 'get_stellar_mass',
-        'magnitude': 'get_magnitude',
-        'source_redshift': 'get_source_redshift',
-        'lens_redshift': 'get_lens_redshift'
+        "einstein_radius": "get_einstein_radius",
+        "ellipticity": "get_ellipticity",
+        "velocity_dispersion": "get_velocity_dispersion",
+        "stellar_mass": "get_stellar_mass",
+        "magnitude": "get_magnitude",
+        "source_redshift": "get_source_redshift",
+        "lens_redshift": "get_lens_redshift",
     }
 
     data = {param: [] for param in parameters}
@@ -43,13 +52,14 @@ def create_table(gg_lens_population, parameters=['einstein_radius', 'ellipticity
 
     return t
 
+
 gg_lens_population_obj = GGLens
 kwargs_lens_cut = {}
 # Drawing the gg lens population
 pop = gg_lens_population_obj.draw_population(kwargs_lens_cut)
 
 # Create the Astropy table with desired parameters
-desired_parameters = ['einstein_radius', 'ellipticity', 'source_redshift']
+desired_parameters = ["einstein_radius", "ellipticity", "source_redshift"]
 table = create_table(pop, parameters=desired_parameters)
 # table.write('output_file.csv', format='csv')
 print(table)

--- a/sim_pipeline/gglens_table_test.py
+++ b/sim_pipeline/gglens_table_test.py
@@ -4,9 +4,9 @@ from sim_pipeline.Pipelines.skypy_pipeline import SkyPyPipeline
 from sim_pipeline.gg_lens import GGLens, theta_e_when_source_infinity
 import numpy as np
 
+
 def create_table(gg_lens_population):
-    """
-    Creates an astropy table for a given gg_lens population.
+    """Creates an astropy table for a given gg_lens population.
 
     :param gg_lens_population: List of GGLens instances.
     :type gg_lens_population: list
@@ -18,8 +18,9 @@ def create_table(gg_lens_population):
     einstein_radii = [lens.get_einstein_radius() for lens in gg_lens_population]
 
     # Create table with desired parameters.
-    t = Table([einstein_radii], names=('Einstein_Radius'))
+    t = Table([einstein_radii], names=("Einstein_Radius"))
     return t
+
 
 @pytest.fixture
 def sample_gg_lens_population():
@@ -27,8 +28,9 @@ def sample_gg_lens_population():
     kwargs_lens_cut = {}
     return gg_lens_population_obj.draw_population(kwargs_lens_cut)
 
+
 def test_create_table(sample_gg_lens_population):
     table = create_table(sample_gg_lens_population)
     assert isinstance(table, Table)
-    assert 'Einstein_Radius' in table.colnames
+    assert "Einstein_Radius" in table.colnames
     # Add more assertions based on your expectations for the table

--- a/sim_pipeline/gglens_table_test.py
+++ b/sim_pipeline/gglens_table_test.py
@@ -1,0 +1,34 @@
+import pytest
+from astropy.table import Table
+from sim_pipeline.Pipelines.skypy_pipeline import SkyPyPipeline
+from sim_pipeline.gg_lens import GGLens, theta_e_when_source_infinity
+import numpy as np
+
+def create_table(gg_lens_population):
+    """
+    Creates an astropy table for a given gg_lens population.
+
+    :param gg_lens_population: List of GGLens instances.
+    :type gg_lens_population: list
+    :return: Astropy table with lens properties.
+    :rtype: `~astropy.table.Table`
+    """
+
+    # Assuming the GGLens class has a method `get_einstein_radius` to get the Einstein radius
+    einstein_radii = [lens.get_einstein_radius() for lens in gg_lens_population]
+
+    # Create table with desired parameters.
+    t = Table([einstein_radii], names=('Einstein_Radius'))
+    return t
+
+@pytest.fixture
+def sample_gg_lens_population():
+    gg_lens_population_obj = GGLens
+    kwargs_lens_cut = {}
+    return gg_lens_population_obj.draw_population(kwargs_lens_cut)
+
+def test_create_table(sample_gg_lens_population):
+    table = create_table(sample_gg_lens_population)
+    assert isinstance(table, Table)
+    assert 'Einstein_Radius' in table.colnames
+    # Add more assertions based on your expectations for the table


### PR DESCRIPTION
This pull request introduces two new files to enhance the sim-pipeline:

gg_lens_table.py:

This module provides functionality to generate an astropy table for a given gg_lens population.
It collects various lens properties such as Einstein Radius, Deflector Ellipticity, Deflector Velocity Dispersion, and more.
This module ensures efficient extraction of properties using a single loop and lets the user select which properties to extract.
gg_lens_table_test.py:

This test file ensures the functionality and serves as a test case only focusing on extracting one parameter. of the gg_lens_table.py.

Additional Comments:

The code has been refactored based on peer review.
Requesting a review to merge these enhancements into the main branch. Feedback and suggestions are most welcome!