### PR TITLE
Better Parameter Validation

### DIFF
--- a/slsim/ParamDistributions/gaussian_mixture_model.py
+++ b/slsim/ParamDistributions/gaussian_mixture_model.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from slsim.Util import check_params
 
 class GaussianMixtureModel:
     """A Gaussian Mixture Model (GMM) class.
@@ -7,12 +7,13 @@ class GaussianMixtureModel:
     This class is used to represent a mixture of Gaussian distributions, each of which
     is defined by its mean, standard deviation and weight.
     """
-
-    def __init__(self, means=None, stds=None, weights=None):
+    @check_params
+    def __init__(self, means, stds, weights):
         """
         The constructor for GaussianMixtureModel class. The default values are the
         means, standard deviations, and weights of the fits to the data in the table
-        2 of https://doi.org/10.1093/mnras/stac2235 and others.
+        2 of https://doi.org/10.1093/mnras/stac2235 and others. See "params.py" for
+        defaults and validation logic.
 
         :param means: the mean values of the Gaussian components.
         :type means: list of float
@@ -21,15 +22,6 @@ class GaussianMixtureModel:
         :param weights: The weights of the Gaussian components in the mixture.
         :type weights: list of float
         """
-        if means is None:
-            means = [0.00330796, -0.07635054, 0.11829008]
-        if stds is None:
-            stds = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
-        if weights is None:
-            weights = [0.62703102, 0.23732313, 0.13564585]
-        assert (
-            len(means) == len(stds) == len(weights)
-        ), "Lengths of means, standard deviations, and weights must be equal."
         self.means = means
         self.stds = stds
         self.weights = weights

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+import numpy as np
+
+class GaussianMixtureModel(BaseModel):
+    means: list[float] = [0.00330796, -0.07635054, 0.11829008]
+    stds: list[float] = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
+    weights: list[float] = [0.62703102, 0.23732313, 0.13564585]
+    

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, PositiveFloat, model_validator, field_validator
+from pydantic import BaseModel, PositiveFloat, model_validator, field_validator
 import numpy as np
 
 class GaussianMixtureModel(BaseModel):

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from pydantic import Field
 import numpy as np
 
 class GaussianMixtureModel(BaseModel):

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -1,12 +1,10 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PositiveFloat, model_validator
 import numpy as np
 
 class GaussianMixtureModel(BaseModel):
     means: list[float] = [0.00330796, -0.07635054, 0.11829008]
-    stds: list[float] = Field(gt=0, 
-                              default=[np.sqrt(0.00283885), np.sqrt(0.01066668), 
-                                       np.sqrt(0.0097978)])
-    weights: list[float] = [0.62703102, 0.23732313, 0.13564585]
+    stds: list[PositiveFloat] = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
+    weights: list[PositiveFloat] = [0.62703102, 0.23732313, 0.13564585]
     
     @model_validator(mode="after")
     def check_lenghts(self):

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -14,7 +14,7 @@ class GaussianMixtureModel(BaseModel):
         return weight_values
 
     @model_validator(mode="after")
-    def check_lenghts(self):
+    def check_lengths(self):
         if len(self.means) != len(self.stds) or len(self.means) != len(self.weights):
             raise ValueError("The lenghts of means, stds and weights must be equal")
         return self

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, PositiveFloat, model_validator
+from pydantic import BaseModel, Field, PositiveFloat, model_validator, field_validator
 import numpy as np
 
 class GaussianMixtureModel(BaseModel):
@@ -6,6 +6,13 @@ class GaussianMixtureModel(BaseModel):
     stds: list[PositiveFloat] = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
     weights: list[PositiveFloat] = [0.62703102, 0.23732313, 0.13564585]
     
+    @field_validator("weights")
+    @classmethod
+    def check_weights(cls, weight_values):
+        if sum(weight_values) != 1:
+            raise ValueError("The sum of the weights must be 1")
+        return weight_values
+
     @model_validator(mode="after")
     def check_lenghts(self):
         if len(self.means) != len(self.stds) or len(self.means) != len(self.weights):

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -1,9 +1,16 @@
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field, model_validator
 import numpy as np
 
 class GaussianMixtureModel(BaseModel):
     means: list[float] = [0.00330796, -0.07635054, 0.11829008]
-    stds: list[float] = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
+    stds: list[float] = Field(gt=0, 
+                              default=[np.sqrt(0.00283885), np.sqrt(0.01066668), 
+                                       np.sqrt(0.0097978)])
     weights: list[float] = [0.62703102, 0.23732313, 0.13564585]
+    
+    @model_validator(mode="before")
+    def check_lenghts(self):
+        if len(self.means) != len(self.stds) or len(self.means) != len(self.weights):
+            raise ValueError("The lenghts of means, stds and weights must be equal")
+        return self
     

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -8,7 +8,7 @@ class GaussianMixtureModel(BaseModel):
                                        np.sqrt(0.0097978)])
     weights: list[float] = [0.62703102, 0.23732313, 0.13564585]
     
-    @model_validator(mode="before")
+    @model_validator(mode="after")
     def check_lenghts(self):
         if len(self.means) != len(self.stds) or len(self.means) != len(self.weights):
             raise ValueError("The lenghts of means, stds and weights must be equal")

--- a/slsim/ParamDistributions/params.py
+++ b/slsim/ParamDistributions/params.py
@@ -16,6 +16,6 @@ class GaussianMixtureModel(BaseModel):
     @model_validator(mode="after")
     def check_lengths(self):
         if len(self.means) != len(self.stds) or len(self.means) != len(self.weights):
-            raise ValueError("The lenghts of means, stds and weights must be equal")
+            raise ValueError("The lengths of means, stds and weights must be equal")
         return self
     

--- a/slsim/Util/__init__.py
+++ b/slsim/Util/__init__.py
@@ -1,0 +1,3 @@
+from .params import check_params
+
+__all__ = ['check_params']

--- a/slsim/Util/params.py
+++ b/slsim/Util/params.py
@@ -13,7 +13,21 @@ class SlSimParameterException(Exception):
 
 _defaults = {}
 
-def check_params(init_fn):
+def check_params(init_fn: Callable) -> Callable:
+    """
+    A decorator for enforcing checking of params in __init__ methods. This
+    decorator will automatically load the default parameters for the class
+    and check that the passed parameters are valid. It expeects a "params.py"
+    file in the same folder as the class definition. Uses pydantic models
+    to enforce types, sanity checks, and defaults.
+
+    From and end user perspective, there is no difference between this and a normal
+    __init__ fn. Developers only need to add @check_params above their __init__
+    method definition to enable this feature, then add their default parameters
+    to the "params.py" file.
+    """
+
+
     if not init_fn.__name__.startswith('__init__'):
         raise SlSimParameterException('pcheck decorator can currently only be used'\
                                     ' with__init__ methods')
@@ -39,15 +53,23 @@ def get_defaults(init_fn):
     modpath = path[start:].split('/')
     modpath = modpath[1:-1] + ["params"]
     modpath = ".".join(["slsim"] + modpath)
+    # Unfortunately, there doesn't seem to be a better way of doing this.
+
     if modpath not in _defaults:
-        _defaults[modpath] = load_defaults(modpath, obj_name)
+        #Little optimization. We cache defaults so we don't have to reload them
+        # every time we construct a new object.
+        _defaults[modpath] = load_parameters(modpath, obj_name)
     return _defaults[modpath]
 
-def load_defaults(modpath, obj_name):
+def load_parameters(modpath, obj_name):
+    """
+    Loads parameters from the "params.py" file which should be in the same folder
+    as the class definition.
+    """
     try:
         defaults = import_module(modpath)
     except ModuleNotFoundError:
-        raise SlSimParameterException('No default parameters found for module '\
+        raise SlSimParameterException('No default parameters found in module '\
                                     f'\"{modpath[-2]}\"')
     try:
         obj_defaults = getattr(defaults, obj_name)

--- a/slsim/Util/params.py
+++ b/slsim/Util/params.py
@@ -1,0 +1,57 @@
+"""
+Utilities for managing parameter defaults and validation in the slsim package.
+Desgined to be unobtrusive to use.
+"""
+from functools import wraps
+from inspect import getsourcefile, getargspec
+from pathlib import Path
+from importlib import import_module
+from typing import Callable
+
+class SlSimParameterException(Exception):
+    pass
+
+_defaults = {}
+
+def check_params(init_fn):
+    if not init_fn.__name__.startswith('__init__'):
+        raise SlSimParameterException('pcheck decorator can currently only be used'\
+                                    ' with__init__ methods')
+
+    @wraps(init_fn)
+    def new_init_fn(obj, *args, **kwargs):
+        # Get function argument names
+        all_args = {}
+        if args:
+            largs = getargspec(init_fn).args
+            for i in range(len(args)):
+                all_args[largs[i+1]] = args[i]
+        all_args.update(kwargs)
+        parsed_args = get_defaults(init_fn)(**all_args)
+        return init_fn(obj, **dict(parsed_args))
+    return new_init_fn
+
+
+def get_defaults(init_fn):
+    path = getsourcefile(init_fn)
+    obj_name = init_fn.__qualname__.split('.')[0]
+    start = path.rfind("slsim")
+    modpath = path[start:].split('/')
+    modpath = modpath[1:-1] + ["params"]
+    modpath = ".".join(["slsim"] + modpath)
+    if modpath not in _defaults:
+        _defaults[modpath] = load_defaults(modpath, obj_name)
+    return _defaults[modpath]
+
+def load_defaults(modpath, obj_name):
+    try:
+        defaults = import_module(modpath)
+    except ModuleNotFoundError:
+        raise SlSimParameterException('No default parameters found for module '\
+                                    f'\"{modpath[-2]}\"')
+    try:
+        obj_defaults = getattr(defaults, obj_name)
+    except AttributeError:
+        raise SlSimParameterException(f'No default parameters found for class '\
+                                    f'\"{obj_name}\"')
+    return obj_defaults


### PR DESCRIPTION
Hey all,

As promised, here is an implemented system for managing parameter defaults and validating input values. This type of checking is critical for long-running pipelines because it catches mistakes very early in a run and provides a very clear explanation of what is wrong. We want to place clear constraints on what types a parameter can be, what values it can take, and what its defaults are. Importantly, we also want to know exactly where all this information is, so we can update it when needed. This system uses [pydantic](https://github.com/pydantic/pydantic) for parameter validation, which is an industrial-strength standard library for this kind of stuff.

Note: This pull request is also intended as basic documentation for people contributing to slsim, so it'll be fairly long.

The system I've built here is very easy to use, but does require a bit of explanation. Currently, it only works (by design) with inputs to \_\_init\_\_ methods on classes but we can always update that in the future. Importantly, it can be implemented on a **per-class basis.**

To mark the class for validation, we simply decorate it with the @param_check decorator:

`slsim/SomeModule/some_class.py`
```python
from slsim.Utils import param_check

class SomeClass:
    
    @param_check
    def __init__(self, param_a, param_b, param_c):
        self.a = param_a
        self.b = param_b
        self.c = param_c
```

Then create a file called "params.py" in the same folder and add something like the following:

`slsim/SomeModule/params.py`

```python
from pydantic import BaseModel, Field

class SomeClass(BaseModel)
    param_a: list[float]
    param_b: str | list[str] = "some_input"
    param_c: int = Field(default = 2, ge=0)
```
Note that the name of the class in `params.py` must match the name of the original class. We can change this if we want. We just have to pick a convention and stick with it.

This will enforce the following constraints on the parameters:
- param_a must be a list of floats
- parm_b must be a string OR a list of strings. If nothing is provided, the default will be "some_input"
- param_c must be an integer that is greater than 0. If nothing is provided, the default will be 2

**Important note:** All of this is entirely transparent to the user. They simply create an instance of `SomeClass` as they normally would. They will only run into an issue if the parameters they provide are invalid.

All validation is done by `pydantic`, which is incredibly fast. I've updated the GaussianMixtureModel class as an example. The class in the associated `params.py` file looks like this:

`slsim/ParamDistributions/params.py`
```python
from pydantic import BaseModel, PositiveFloat, model_validator
import numpy as np

class GaussianMixtureModel(BaseModel):
    means: list[float] = [0.00330796, -0.07635054, 0.11829008]
    stds: list[PositiveFloat] = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
    weights: list[PositiveFloat] = [0.62703102, 0.23732313, 0.13564585]
    
    @field_validator("weights")
    @classmethod
    def check_weights(cls, weight_values):
        if sum(weight_values) != 1:
            raise ValueError("The sum of the weights must be 1")
        return weight_values

    @model_validator(mode="after")
    def check_lenghts(self):
        if len(self.means) != len(self.stds) or len(self.means) != len(self.weights):
            raise ValueError("The lenghts of means, stds and weights must be equal")
        return self
```
Note: I just pulled the defaults from the original class definition.

This does three things in addition to simple type checking:
1. Ensures stds and weights are positive values
2. Ensures the total value of the weights == 1
3. Ensures that the length of all three parameters are the same

Some of these were already implemented in the GaussianMixtureModel \_\_init\_\_ function. However, the checking is now much more robust and requires much less code. GaussianMixtureModel now just looks like this
`slsim/ParamDistributions/gaussian_mixture_model.py`
```python

class GaussianMixtureModel:
    """A Gaussian Mixture Model (GMM) class.

    This class is used to represent a mixture of Gaussian distributions, each of which
    is defined by its mean, standard deviation and weight.
    """
    @check_params
    def __init__(self, means, stds, weights):
        """
        The constructor for GaussianMixtureModel class. The default values are the
        means, standard deviations, and weights of the fits to the data in the table
        2 of https://doi.org/10.1093/mnras/stac2235 and others. See "params.py" for
        defaults and validation logic.

        :param means: the mean values of the Gaussian components.
        :type means: list of float
        :param stds: The standard deviations of the Gaussian components.
        :type stds: list of float
        :param weights: The weights of the Gaussian components in the mixture.
        :type weights: list of float
        """
        self.means = means
        self.stds = stds
        self.weights = weights
```



Here's an example of a failure case:

```
>>> from slsim.ParamDistributions.gaussian_mixture_model import GaussianMixtureModel as GMM
>>> GMM(means=[1, 2, 3], stds = [4, 5], weights = [0.4, 0.4, 0.2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/patrick/code/DESC/slsim/slsim/Util/params.py", line 45, in new_init_fn
    parsed_args = get_defaults(init_fn)(**pargs, **kwargs)
  File "/Users/patrick/opt/anaconda3/envs/dev/lib/python3.10/site-packages/pydantic/main.py", line 164, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 1 validation error for GaussianMixtureModel
  Value error, The lengths of means, stds and weights must be equal [type=value_error, input_value={'means': [1, 2, 3], 'std...ights': [0.4, 0.4, 0.2]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/value_error
```

Where we see it is telling us that our three input arrays have to be the same length.

Additional notes:

- We can introduce higher-level validation tools as needed. For example, we could validate that some value has particular units as defined in `astropy.units.` This will require some additional code, but I've basically already written it for `cosmap` so it will be straightforward.
- Related to the above, pydantic is incredibly powerful and has tons of features. We likely won't use most of them, but they're always there. 
- We can eventually extend this system to read information in from configuration files, if we want.
- We can always expand this system to do checkin on more than just initialization functions, but this will definitely introduce some significant complexity on the backend. Happy to do this work though.
- I would strongly recommend we update our minimum Python version to at least 3.10. This allows us to write union types (that is, marking a parameter as allowing multiple types) like `float | int` whereas 3.8 would require `Union[float, int]` and an additional import. Performance has also been a big focus of more recent Python versions, so we're losing out on all that if we stay on 3.8. 
- One thing we may want to change about this code as written is the naming scheme. "Parameter" is the standard name for function inputs, but of course it's also a word we use in a scientific concept. So we may want to pick some convention that avoids confusion.