### PR TITLE
Added movie interpolation + test function

### DIFF
--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -44,21 +44,29 @@ def sinusoidal_variability(t, amp, freq):
     """
     return amp * np.sin(2 * np.pi * freq * t)
 
-def interpolate_variability(Movie, Orig_timestamps, New_timestamps):
-    """Interpolates a variable source to any given time series
+def interpolate_variability(Image_series, Orig_timestamps, New_timestamps):
+    """Interpolates a variable source to any given time series.
 
-    :param Movie: 3 dimensional array of shape (t, x, y)
-        relating to snapshots of a variable object in source plane
+    :param Image_series: 3 dimensional array of shape (t, x, y) relating to snapshots of
+        a variable object in source plane
     :param Orig_timestamps: Series of timestamps which represent original snapshots
     :param New_timestamps: Series of new timestamps to interpolate to
-    :return: Linearly interpolated movie along time axis
+    :return: Linearly interpolated image along time axis
     """
-    initial_shape = np.shape(Movie)
+    initial_shape = np.shape(Image_series)
     npix = initial_shape[1] * initial_shape[2]
-    space_positions = np.linspace(1, npix, npix)                        # Order pixels
-    intermediate_movie = np.reshape(Movie, (initial_shape[0], npix))    # Reshape into (t, space) array
-    interpolation = scipy.interpolate.RegularGridInterpolator((Orig_timestamps, space_positions),
-                                        intermediate_movie, bounds_error=False, fill_value=None)
-    new_points = np.meshgrid(New_timestamps, space_positions, indexing='ij')
-    movie_resampled = interpolation((new_points[0], new_points[1]))     # Resample
-    return np.reshape(movie_resampled, (np.size(New_timestamps), initial_shape[1], initial_shape[2]))
+    space_positions = np.linspace(1, npix, npix)  # Order pixels
+    intermediate_movie = np.reshape(
+        Image_series, (initial_shape[0], npix)
+    )  # Reshape into (t, space) array
+    interpolation = scipy.interpolate.RegularGridInterpolator(
+        (Orig_timestamps, space_positions),
+        intermediate_movie,
+        bounds_error=False,
+        fill_value=None,
+    )
+    new_points = np.meshgrid(New_timestamps, space_positions, indexing="ij")
+    Images_resampled = interpolation((new_points[0], new_points[1]))  # Resample
+    return np.reshape(
+        Images_resampled, (np.size(New_timestamps), initial_shape[1], initial_shape[2])
+    )

--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 
 """This class aims to have realistic variability models for AGN and Supernovae."""
 
@@ -42,3 +43,22 @@ def sinusoidal_variability(t, amp, freq):
     :return: variability for the given time
     """
     return amp * np.sin(2 * np.pi * freq * t)
+
+def interpolate_variability(Movie, Orig_timestamps, New_timestamps):
+    """Interpolates a variable source to any given time series
+
+    :param Movie: 3 dimensional array of shape (t, x, y)
+        relating to snapshots of a variable object in source plane
+    :param Orig_timestamps: Series of timestamps which represent original snapshots
+    :param New_timestamps: Series of new timestamps to interpolate to
+    :return: Linearly interpolated movie along time axis
+    """
+    initial_shape = np.shape(Movie)
+    npix = initial_shape[1] * initial_shape[2]
+    space_positions = np.linspace(1, npix, npix)                        # Order pixels
+    intermediate_movie = np.reshape(Movie, (initial_shape[0], npix))    # Reshape into (t, space) array
+    interpolation = scipy.interpolate.RegularGridInterpolator((Orig_timestamps, space_positions),
+                                        intermediate_movie, bounds_error=False, fill_value=None)
+    new_points = np.meshgrid(New_timestamps, space_positions, indexing='ij')
+    movie_resampled = interpolation((new_points[0], new_points[1]))     # Resample
+    return np.reshape(movie_resampled, (np.size(New_timestamps), initial_shape[1], initial_shape[2]))

--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -63,7 +63,7 @@ def interpolate_variability(Image_series, Orig_timestamps, New_timestamps):
         (Orig_timestamps, space_positions),
         intermediate_movie,
         bounds_error=False,
-        fill_value=None
+        fill_value=None,
     )
     new_points = np.meshgrid(New_timestamps, space_positions, indexing="ij")
     Images_resampled = interpolation((new_points[0], new_points[1]))

--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -55,18 +55,18 @@ def interpolate_variability(Image_series, Orig_timestamps, New_timestamps):
     """
     initial_shape = np.shape(Image_series)
     npix = initial_shape[1] * initial_shape[2]
-    space_positions = np.linspace(1, npix, npix)  # Order pixels
+    space_positions = np.linspace(1, npix, npix)
     intermediate_movie = np.reshape(
         Image_series, (initial_shape[0], npix)
-    )  # Reshape into (t, space) array
+    )
     interpolation = scipy.interpolate.RegularGridInterpolator(
         (Orig_timestamps, space_positions),
         intermediate_movie,
         bounds_error=False,
-        fill_value=None,
+        fill_value=None
     )
     new_points = np.meshgrid(New_timestamps, space_positions, indexing="ij")
-    Images_resampled = interpolation((new_points[0], new_points[1]))  # Resample
+    Images_resampled = interpolation((new_points[0], new_points[1]))
     return np.reshape(
         Images_resampled, (np.size(New_timestamps), initial_shape[1], initial_shape[2])
     )

--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy
 
-"""This class aims to have realistic variability models for AGN and Supernovae."""
+"""This class aims to have realistic variability models for AGN and supernovae."""
 
 
 class Variability(object):

--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -44,6 +44,7 @@ def sinusoidal_variability(t, amp, freq):
     """
     return amp * np.sin(2 * np.pi * freq * t)
 
+
 def interpolate_variability(Image_series, Orig_timestamps, New_timestamps):
     """Interpolates a variable source to any given time series.
 
@@ -56,9 +57,7 @@ def interpolate_variability(Image_series, Orig_timestamps, New_timestamps):
     initial_shape = np.shape(Image_series)
     npix = initial_shape[1] * initial_shape[2]
     space_positions = np.linspace(1, npix, npix)
-    intermediate_movie = np.reshape(
-        Image_series, (initial_shape[0], npix)
-    )
+    intermediate_movie = np.reshape(Image_series, (initial_shape[0], npix))
     interpolation = scipy.interpolate.RegularGridInterpolator(
         (Orig_timestamps, space_positions),
         intermediate_movie,

--- a/slsim/Sources/source_variability/variability.py
+++ b/slsim/Sources/source_variability/variability.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy
 
 """This class aims to have realistic variability models for AGN and supernovae."""
 
@@ -43,29 +42,3 @@ def sinusoidal_variability(t, amp, freq):
     :return: variability for the given time
     """
     return amp * np.sin(2 * np.pi * freq * t)
-
-
-def interpolate_variability(Image_series, Orig_timestamps, New_timestamps):
-    """Interpolates a variable source to any given time series.
-
-    :param Image_series: 3 dimensional array of shape (t, x, y) relating to snapshots of
-        a variable object in source plane
-    :param Orig_timestamps: Series of timestamps which represent original snapshots
-    :param New_timestamps: Series of new timestamps to interpolate to
-    :return: Linearly interpolated image along time axis
-    """
-    initial_shape = np.shape(Image_series)
-    npix = initial_shape[1] * initial_shape[2]
-    space_positions = np.linspace(1, npix, npix)
-    intermediate_movie = np.reshape(Image_series, (initial_shape[0], npix))
-    interpolation = scipy.interpolate.RegularGridInterpolator(
-        (Orig_timestamps, space_positions),
-        intermediate_movie,
-        bounds_error=False,
-        fill_value=None,
-    )
-    new_points = np.meshgrid(New_timestamps, space_positions, indexing="ij")
-    Images_resampled = interpolation((new_points[0], new_points[1]))
-    return np.reshape(
-        Images_resampled, (np.size(New_timestamps), initial_shape[1], initial_shape[2])
-    )

--- a/slsim/Util/param_util.py
+++ b/slsim/Util/param_util.py
@@ -105,7 +105,8 @@ def pixels_to_images(pixels, original_shape):
 
     :param pixels: Series of pixel snapshots to arrange back into the original image
         shape
-    :param original_shape: The original shape of the image snapshots
+    :param original_shape: The original output of np.shape(original_image_series)
+        [tuple]
     :return: Series of image snapshots
     """
     return np.reshape(

--- a/slsim/Util/param_util.py
+++ b/slsim/Util/param_util.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.signal import convolve2d, fftconvolve
+import scipy
 
 
 def epsilon2e(epsilon):
@@ -85,3 +86,60 @@ def magnitude_to_amplitude(magnitude, mag_zero_point):
     delta_m = magnitude - mag_zero_point
     counts = 10 ** (-delta_m / 2.5)
     return counts
+
+
+def images_to_pixels(image_series):
+    """Converts a series of image snapshots into a list of pixel snapshots.
+
+    :param image_series: Series of images to convert
+    :return: List of pixel snapshots
+    """
+    initial_shape = np.shape(image_series)
+    number_of_pixels = initial_shape[1] * initial_shape[2]
+    return np.reshape(image_series, (initial_shape[0], number_of_pixels))
+
+
+def pixels_to_images(pixels, original_shape):
+    """Converts a string of pixel snapshots back into a series of image snapshots. This
+    is the inverse of images_to_pixels.
+
+    :param pixels: Series of pixel snapshots to arrange back into the original image
+        shape
+    :param original_shape: The original shape of the image snapshots
+    :return: Series of image snapshots
+    """
+    return np.reshape(
+        pixels, (np.size(pixels, 0), original_shape[1], original_shape[2])
+    )
+
+
+def interpolate_variability(image_series, orig_timestamps, new_timestamps):
+    """Interpolates between time stamps of a series of image snapshots. This will be
+    important for future implimentation of microlensing.
+
+    :param image_series: 3 dimensional array of shape (snapshot_index, x, y) defining
+        snapshots of a variable object in (x, y) coordinates
+    :param orig_timestamps: List of timestamps which represent the time of each
+        simulated observation, must be same length as np.size(image_series, 0)
+    :param new_timestamps: List of new timestamps to interpolate the series of snapshots
+        to
+    :return: Linearly interpolated series of snapshots at the new timestamps on a pixel-
+        by-pixel basis
+    """
+    time_varying_pixels = images_to_pixels(image_series)
+    number_pixels = np.size(time_varying_pixels, 1)
+    pixel_positions = np.linspace(1, number_pixels, number_pixels)
+
+    # prepare the interpolation grid. bounds_error=False allows for endpoint
+    # "interpolation" (e.g. allows t=0 in new_timestamps)
+    interpolation = scipy.interpolate.RegularGridInterpolator(
+        (orig_timestamps, pixel_positions),
+        time_varying_pixels,
+        bounds_error=False,
+        fill_value=None,
+    )
+
+    # define new times to interpolate to, and do not interpolate between pixels
+    new_time_points = np.meshgrid(new_timestamps, pixel_positions, indexing="ij")
+    pixels_resampled = interpolation((new_time_points[0], new_time_points[1]))
+    return pixels_to_images(pixels_resampled, np.shape(image_series))

--- a/tests/test_Source/test_source_variability.py
+++ b/tests/test_Source/test_source_variability.py
@@ -1,6 +1,5 @@
 import numpy as np
 from slsim.Sources.source_variability.variability import Variability
-from slsim.Sources.source_variability.variability import interpolate_variability
 from numpy import testing as npt
 import pytest
 
@@ -26,34 +25,6 @@ class TestVariability:
         result = variability.variability_at_time(observation_times)
         expected_result = np.array([-0.43030122, -0.97536797, -0.14773276])
         npt.assert_almost_equal(result, expected_result, decimal=5)
-
-    def test_interpolation_for_sinusoidal(self):
-        kwargs_model00 = {"amp": 1.0, "freq": 0.5}
-        kwargs_model01 = {"amp": 2.0, "freq": 1}
-        obs_snapshots = np.array([0, 1, np.pi])
-        new_snapshots = np.array([0, 0.5, 1, 1.5])
-        movie = np.zeros((3, 2, 2))
-        movie[:, 0, 0] = Variability(
-            "sinusoidal", **kwargs_model00
-        ).variability_at_time(obs_snapshots)
-        movie[:, 0, 1] = Variability(
-            "sinusoidal", **kwargs_model01
-        ).variability_at_time(obs_snapshots)
-        movie[:, 1, 0] = np.array([4, 2, 2])
-        movie[:, 1, 1] = np.array([0, -6, 0])
-        interp_movie = interpolate_variability(movie, obs_snapshots, new_snapshots)
-        expect_movie = np.zeros((4, 2, 2))
-        expect_movie[:, 0, 0] = np.array(
-            [0.0, 0.0, 0.0, (np.sin(np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)]
-        )
-        expect_movie[:, 0, 1] = np.array(
-            [0.0, 0.0, 0.0, (2 * np.sin(2 * np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)]
-        )
-        expect_movie[:, 1, 0] = np.array([4.0, 3.0, 2.0, 2.0])
-        expect_movie[:, 1, 1] = np.array(
-            [0.0, -3.0, -6.0, -6 + (0.0 + 6.0) * 0.5 / (np.pi - 1.0)]
-        )
-        npt.assert_almost_equal(interp_movie, expect_movie, decimal=5)
 
 
 if __name__ == "__main__":

--- a/tests/test_Source/test_source_variability.py
+++ b/tests/test_Source/test_source_variability.py
@@ -33,17 +33,28 @@ class TestVariability:
         obs_snapshots = np.array([0, 1, np.pi])
         new_snapshots = np.array([0, 0.5, 1, 1.5])
         movie = np.zeros((3, 2, 2))
-        movie[:, 0, 0] = Variability("sinusoidal", **kwargs_model00).variability_at_time(obs_snapshots)
-        movie[:, 0, 1] = Variability("sinusoidal", **kwargs_model01).variability_at_time(obs_snapshots)
+        movie[:, 0, 0] = Variability(
+            "sinusoidal", **kwargs_model00
+        ).variability_at_time(obs_snapshots)
+        movie[:, 0, 1] = Variability(
+            "sinusoidal", **kwargs_model01
+        ).variability_at_time(obs_snapshots)
         movie[:, 1, 0] = np.array([4, 2, 2])
         movie[:, 1, 1] = np.array([0, -6, 0])
         interp_movie = interpolate_variability(movie, obs_snapshots, new_snapshots)
         expect_movie = np.zeros((4, 2, 2))
-        expect_movie[:, 0, 0] = np.array([0.0, 0.0, 0.0, (np.sin(np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)])
-        expect_movie[:, 0, 1] = np.array([0.0, 0.0, 0.0, (2 * np.sin(2 * np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)])
+        expect_movie[:, 0, 0] = np.array(
+            [0.0, 0.0, 0.0, (np.sin(np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)]
+        )
+        expect_movie[:, 0, 1] = np.array(
+            [0.0, 0.0, 0.0, (2 * np.sin(2 * np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)]
+        )
         expect_movie[:, 1, 0] = np.array([4.0, 3.0, 2.0, 2.0])
-        expect_movie[:, 1, 1] = np.array([0.0, -3.0, -6.0, -6 + (0.0 + 6.0) * 0.5 / (np.pi - 1.0)])
+        expect_movie[:, 1, 1] = np.array(
+            [0.0, -3.0, -6.0, -6 + (0.0 + 6.0) * 0.5 / (np.pi - 1.0)]
+        )
         npt.assert_almost_equal(interp_movie, expect_movie, decimal=5)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_Source/test_source_variability.py
+++ b/tests/test_Source/test_source_variability.py
@@ -1,5 +1,6 @@
 import numpy as np
 from slsim.Sources.source_variability.variability import Variability
+from slsim.Sources.source_variability.variability import interpolate_variability
 from numpy import testing as npt
 import pytest
 
@@ -26,6 +27,23 @@ class TestVariability:
         expected_result = np.array([-0.43030122, -0.97536797, -0.14773276])
         npt.assert_almost_equal(result, expected_result, decimal=5)
 
+    def test_interpolation_for_sinusoidal(self):
+        kwargs_model00 = {"amp": 1.0, "freq": 0.5}
+        kwargs_model01 = {"amp": 2.0, "freq": 1}
+        obs_snapshots = np.array([0, 1, np.pi])
+        new_snapshots = np.array([0, 0.5, 1, 1.5])
+        movie = np.zeros((3, 2, 2))
+        movie[:, 0, 0] = Variability("sinusoidal", **kwargs_model00).variability_at_time(obs_snapshots)
+        movie[:, 0, 1] = Variability("sinusoidal", **kwargs_model01).variability_at_time(obs_snapshots)
+        movie[:, 1, 0] = np.array([4, 2, 2])
+        movie[:, 1, 1] = np.array([0, -6, 0])
+        interp_movie = interpolate_variability(movie, obs_snapshots, new_snapshots)
+        expect_movie = np.zeros((4, 2, 2))
+        expect_movie[:, 0, 0] = np.array([0.0, 0.0, 0.0, (np.sin(np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)])
+        expect_movie[:, 0, 1] = np.array([0.0, 0.0, 0.0, (2 * np.sin(2 * np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)])
+        expect_movie[:, 1, 0] = np.array([4.0, 3.0, 2.0, 2.0])
+        expect_movie[:, 1, 1] = np.array([0.0, -3.0, -6.0, -6 + (0.0 + 6.0) * 0.5 / (np.pi - 1.0)])
+        npt.assert_almost_equal(interp_movie, expect_movie, decimal=5)
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_param_util.py
+++ b/tests/test_param_util.py
@@ -1,11 +1,16 @@
 import numpy as np
 import os
+from numpy import testing as npt
 from slsim.Util.param_util import (
     epsilon2e,
     e2epsilon,
     random_ra_dec,
     convolved_image,
+    interpolate_variability,
+    images_to_pixels,
+    pixels_to_images,
 )
+from slsim.Sources.source_variability.variability import Variability
 
 
 def test_epsilon2e():
@@ -31,3 +36,67 @@ def test_convolved_image():
     c_image_1 = convolved_image(image, psf, convolution_type="grid")
     assert c_image.shape[0] == 101
     assert c_image_1.shape[0] == 101
+
+
+def test_images_to_pixels():
+    image = np.reshape(np.linspace(1, 27, 27), (3, 3, 3))
+    ordered_pixels = images_to_pixels(image)
+    manually_ordered_pixels = np.concatenate(
+        (image[0, 0, :], image[0, 1, :], image[0, 2, :])
+    )
+    # Test pixels are properly ordered
+    assert all(ordered_pixels[0] == manually_ordered_pixels)
+    # Test axis 0 is still the snapshot index
+    assert all(ordered_pixels[1] == ordered_pixels[0] + 9)
+    assert all(ordered_pixels[2] == ordered_pixels[1] + 9)
+
+
+def test_pixels_to_images():
+    image = np.reshape(np.linspace(1, 27, 27), (3, 3, 3))
+    ordered_pixels = images_to_pixels(image)
+    image_reconstructed = pixels_to_images(ordered_pixels, np.shape(image))
+    # Test image_reconstructed is exactly the original image
+    assert np.all(image_reconstructed == image)
+
+
+def test_interpolation_for_sinusoidal():
+    # define original and new timestamps for interpolation.
+    # tests: interpolating from boundary point to same boundary point
+    #        midpoint between two timestamps
+    #        interpolating from a central timestamp to same timestamp
+    #        interpolating to arbitrary timestamp (not at midpoint)
+    #        output shape is correct
+    obs_snapshots = np.array([0, 1, np.pi])
+    new_snapshots = np.array([0, 0.5, 1, 1.5])
+    # define 3 snapshots of 4 independent, time-varying pixels
+    kwargs_model00 = {"amp": 1.0, "freq": 0.5}
+    kwargs_model01 = {"amp": 2.0, "freq": 1.0}
+    # manually set each pixel's values
+    image_snapshots = np.zeros((3, 2, 2))
+    image_snapshots[:, 0, 0] = Variability(
+        "sinusoidal", **kwargs_model00
+    ).variability_at_time(obs_snapshots)
+    image_snapshots[:, 0, 1] = Variability(
+        "sinusoidal", **kwargs_model01
+    ).variability_at_time(obs_snapshots)
+    # also define two pixels as simple values, including negative
+    image_snapshots[:, 1, 0] = np.array([4, 2, 2])
+    image_snapshots[:, 1, 1] = np.array([0, -6, 0])
+    # interpolate to new timestamps
+    interp_image_snapshots = interpolate_variability(
+        image_snapshots, obs_snapshots, new_snapshots
+    )
+    # manually calculate expectation snapshots
+    expect_image_snapshots = np.zeros((4, 2, 2))
+    expect_image_snapshots[:, 0, 0] = np.array(
+        [0.0, 0.0, 0.0, (np.sin(np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)]
+    )
+    expect_image_snapshots[:, 0, 1] = np.array(
+        [0.0, 0.0, 0.0, (2.0 * np.sin(2.0 * np.pi * np.pi) - 0.0) * 0.5 / (np.pi - 1.0)]
+    )
+    expect_image_snapshots[:, 1, 0] = np.array([4.0, 3.0, 2.0, 2.0])
+    expect_image_snapshots[:, 1, 1] = np.array(
+        [0.0, -3.0, -6.0, -6.0 + (0.0 + 6.0) * 0.5 / (np.pi - 1.0)]
+    )
+    # compare to 5 decimal points
+    npt.assert_almost_equal(interp_image_snapshots, expect_image_snapshots, decimal=5)


### PR DESCRIPTION
Added movie interpolation which acts linearly in time. Movie is expected of shape (t, x, y) where the x and y coordinates are generic spatial coordinates. The t value defines the snapshot number. I attempted to keep documentation like the other functions but it still may need tweaking. The time axis must correspond to the Orig_timestamps array, where the simulated times were stored. New_timestamps may be arbitrary. Extrapolation beyond the original bounds is done simply by repeating the boundary values for every pixel.

Also added is a test function which uses the sinusoidal variability as well as generic values to represent "pixel" snapshots at 3 original time steps. The test function interpolates between these values for each pixel at the following important test areas: An endpoint, a midpoint between two points, a central value which is also an original point, and an arbitrary point between an extra long gap (interpolates to 1.5 from original time values 1.0 and np.pi). The test explicitly compares the array created through my function and the expectation calculated pixel by pixel through linear interpolation. I kept it as small as I could.

After downloading the required testing python packages, I received confirmation that it succeeds. I made some plots of it working on significantly larger movies as well (1000 x 400 x 400, summed over pixels in the source plane), which I can share if you want to see it as well.