### PR TITLE
Ignore lsst_science_pipeline.py for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,5 @@ comment:                  # this is a top-level key
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: false        # [true :: must have a base report to post]
   require_head: true       # [true :: must have a head report to post]
+  ignore:
+    - "slsim/lsst_science_pipeline.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,4 @@ comment:                  # this is a top-level key
   require_head: true       # [true :: must have a head report to post]
   ignore:
     - "slsim/lsst_science_pipeline.py"
+    - "setup.py"

--- a/slsim/lsst_science_pipeline.py
+++ b/slsim/lsst_science_pipeline.py
@@ -27,7 +27,7 @@ uses some of the packages provided by the LSST Science Pipeline.
 
 
 def DC2_cutout(ra, dec, num_pix, butler, band):
-    """Draws a cutout from the DC2 data based on the given ra, dec pair. For this one
+    """Draws a cutout from the DC2 data based on the given ra, dec pair. For this, one
     needs to provide a butler to this function. To initiate Butler, you need to specify
     data configuration and collection of the data.
 


### PR DESCRIPTION
This PR makes `codecov` to completely ignore lsst_science_pipeline.py, following #102.