### PR TITLE
Ignore lsst_science_pipeline.py for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,5 @@ comment:                  # this is a top-level key
   require_base: false        # [true :: must have a base report to post]
   require_head: true       # [true :: must have a head report to post]
 ignore:
-  - "slsim/slsim/lsst_science_pipeline.py"
-  - "slsim/setup.py"
+  - "slsim/lsst_science_pipeline.py"
+  - "setup.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,6 @@ comment:                  # this is a top-level key
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: false        # [true :: must have a base report to post]
   require_head: true       # [true :: must have a head report to post]
-  ignore:
-    - "slsim/slsim/lsst_science_pipeline.py"
-    - "slsim/setup.py"
+ignore:
+  - "slsim/slsim/lsst_science_pipeline.py"
+  - "slsim/setup.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,4 @@ comment:                  # this is a top-level key
 ignore:
   - "slsim/lsst_science_pipeline.py"
   - "setup.py"
+  - "tests/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,5 @@ comment:                  # this is a top-level key
   require_base: false        # [true :: must have a base report to post]
   require_head: true       # [true :: must have a head report to post]
   ignore:
-    - "slsim/lsst_science_pipeline.py"
-    - "setup.py"
+    - "slsim/slsim/lsst_science_pipeline.py"
+    - "slsim/setup.py"


### PR DESCRIPTION
This PR makes `codecov` to completely ignore lsst_science_pipeline.py, following #102.