### PR TITLE
Bug Fix in Schechter Integral

### DIFF
--- a/slsim/Deflectors/velocity_dispersion.py
+++ b/slsim/Deflectors/velocity_dispersion.py
@@ -282,7 +282,9 @@ def schechter_vel_disp_redshift(
 
     # gamma function integrand
     def f(lnx, a):
-        return np.exp(lnx)*np.exp(a * lnx - np.exp(lnx)) if lnx < lnxmax.max() else 0.0
+        return (
+            np.exp(lnx) * np.exp(a * lnx - np.exp(lnx)) if lnx < lnxmax.max() else 0.0
+        )
 
     # integrate gamma function for each redshift
 

--- a/slsim/Deflectors/velocity_dispersion.py
+++ b/slsim/Deflectors/velocity_dispersion.py
@@ -282,7 +282,7 @@ def schechter_vel_disp_redshift(
 
     # gamma function integrand
     def f(lnx, a):
-        return np.exp(a * lnx - np.exp(lnx)) if lnx < lnxmax.max() else 0.0
+        return np.exp(lnx)*np.exp(a * lnx - np.exp(lnx)) if lnx < lnxmax.max() else 0.0
 
     # integrate gamma function for each redshift
 

--- a/tests/test_Deflectors/test_velocity_dispersion.py
+++ b/tests/test_Deflectors/test_velocity_dispersion.py
@@ -59,7 +59,7 @@ def test_schechter_vdf():
         cosmology,
         noise=True,
     )
-    assert len(z_list) == 373
+    assert len(z_list) == 117
 
     # plt.hist(np.log10(vel_disp_list))
     # plt.show()


### PR DESCRIPTION
Fix related to issue #110. The integral is made with respect to log(x) rather than x, requiring an additional factor of x=exp(log(x)) when making the change of variables.

This fixes the discrepancy when evaluating for different v_min values - updated reproducible example:
<img width="497" alt="image" src="https://github.com/LSST-strong-lensing/slsim/assets/54064261/2e4a5e8a-505d-4efe-958c-dc4c007ab0da">
