### PR TITLE
faster lens equation solver for EPL+shear+convergence 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 skypy
-lenstronomy>=1.11.2
+lenstronomy>=1.11.8
 astropy>=5.2
 numpy
 scipy

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -4,6 +4,7 @@ from lenstronomy.Util import constants
 from lenstronomy.LensModel.lens_model import LensModel
 from lenstronomy.LightModel.light_model import LightModel
 from lenstronomy.LensModel.Solver.lens_equation_solver import LensEquationSolver
+from lenstronomy.LensModel.Solver.lens_equation_solver import analytical_lens_model_support
 from slsim.ParamDistributions.gaussian_mixture_model import GaussianMixtureModel
 from lenstronomy.Util import util, data_util
 from slsim.lensed_system_base import LensedSystemBase
@@ -42,7 +43,7 @@ class Lens(LensedSystemBase):
         :type variability_model: str
         :param kwargs_variability: keyword arguments for the variability of a source.
          This is associated with an input for Variability class.
-        :type kwargs_variab: list of str
+        :type kwargs_variability: list of str
         :param test_area: area of disk around one lensing galaxies to be investigated
             on (in arc-seconds^2)
         :param mixgauss_weights: weights of the Gaussian mixture
@@ -115,13 +116,15 @@ class Lens(LensedSystemBase):
             source_pos_x, source_pos_y = self.source.extended_source_position(
                 center_lens=self.deflector_position, draw_area=self.test_area
             )
-            # TODO: analytical solver possible but currently does not support the
-            #  convergence term
+            if analytical_lens_model_support(lens_model_list) is True:
+                solver = "analytical"
+            else:
+                solver = "lenstronomy"
             self._image_positions = lens_eq_solver.image_position_from_source(
                 source_pos_x,
                 source_pos_y,
                 kwargs_lens,
-                solver="lenstronomy",
+                solver=solver,
                 search_window=self.einstein_radius * 6,
                 min_distance=self.einstein_radius * 6 / 200,
                 magnification_limit=self._magnification_limit,
@@ -142,13 +145,16 @@ class Lens(LensedSystemBase):
             point_source_pos_x, point_source_pos_y = self.source.point_source_position(
                 center_lens=self.deflector_position, draw_area=self.test_area
             )
-            # TODO: analytical solver possible but currently does not support the
-            #  convergence term
+            # uses analytical lens equation solver in case it is supported by lenstronomy for speed-up
+            if analytical_lens_model_support(lens_model_list) is True:
+                solver = "analytical"
+            else:
+                solver = "lenstronomy"
             self._point_image_positions = lens_eq_solver.image_position_from_source(
                 point_source_pos_x,
                 point_source_pos_y,
                 kwargs_lens,
-                solver="lenstronomy",
+                solver=solver,
                 search_window=self.einstein_radius * 6,
                 min_distance=self.einstein_radius * 6 / 200,
                 magnification_limit=self._magnification_limit,

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -20,6 +20,7 @@ class Lens(LensedSystemBase):
         deflector_dict,
         cosmo,
         source_type="extended",
+        lens_equation_solver="lenstronomy_analytical",
         variability_model=None,
         kwargs_variability=None,
         test_area=4 * np.pi,
@@ -38,6 +39,9 @@ class Lens(LensedSystemBase):
         :param source_type: type of the source 'extended' or 'point_source' or
          'point_plus_extended' supported
         :type source_type: str
+        :param lens_equation_solver: type of lens equation solver; currently supporting
+         "lenstronomy_analytical" and "lenstronomy_general"
+        :type lens_equation_solver: str
         :param variability_model: keyword for variability model to be used. This is an
          input for the Variability class.
         :type variability_model: str
@@ -67,6 +71,7 @@ class Lens(LensedSystemBase):
 
         self.cosmo = cosmo
         self._source_type = source_type
+        self._lens_equation_solver = lens_equation_solver
         self._mixgauss_means = mixgauss_means
         self._mixgauss_stds = mixgauss_stds
         self._mixgauss_weights = mixgauss_weights
@@ -116,7 +121,8 @@ class Lens(LensedSystemBase):
             source_pos_x, source_pos_y = self.source.extended_source_position(
                 center_lens=self.deflector_position, draw_area=self.test_area
             )
-            if analytical_lens_model_support(lens_model_list) is True:
+            if self._lens_equation_solver == "lenstronomy_analytical" and \
+                    analytical_lens_model_support(lens_model_list) is True:
                 solver = "analytical"
             else:
                 solver = "lenstronomy"
@@ -146,7 +152,8 @@ class Lens(LensedSystemBase):
                 center_lens=self.deflector_position, draw_area=self.test_area
             )
             # uses analytical lens equation solver in case it is supported by lenstronomy for speed-up
-            if analytical_lens_model_support(lens_model_list) is True:
+            if self._lens_equation_solver == "lenstronomy_analytical" and \
+                    analytical_lens_model_support(lens_model_list) is True:
                 solver = "analytical"
             else:
                 solver = "lenstronomy"

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -122,7 +122,9 @@ class TestLens(object):
             deflector_dict=self.deflector_dict,
             cosmo=cosmo,
         )
-        gg_lens.validity_test()
+        while True:
+            gg_lens.validity_test()
+            break
 
         gg_lens = Lens(
             lens_equation_solver="lenstronomy_analytical",
@@ -130,7 +132,9 @@ class TestLens(object):
             deflector_dict=self.deflector_dict,
             cosmo=cosmo,
         )
-        gg_lens.validity_test()
+        while True:
+            gg_lens.validity_test()
+            break
 
 
 

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -111,6 +111,28 @@ class TestLens(object):
         npt.assert_almost_equal(dt_days, observer_times, decimal=5)
         npt.assert_almost_equal(dt_days2, observer_times2, decimal=5)
 
+    def test_lens_equation_solver(self):
+        """
+        tests analytical and numerical lens equation solver options
+        """
+        cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        gg_lens = Lens(
+            lens_equation_solver="lenstronomy_default",
+            source_dict=self.source_dict,
+            deflector_dict=self.deflector_dict,
+            cosmo=cosmo,
+        )
+        gg_lens.validity_test()
+
+        gg_lens = Lens(
+            lens_equation_solver="lenstronomy_analytical",
+            source_dict=self.source_dict,
+            deflector_dict=self.deflector_dict,
+            cosmo=cosmo,
+        )
+        gg_lens.validity_test()
+
+
 
 @pytest.fixture
 def pes_lens_instance():


### PR DESCRIPTION
faster lens equation solver for EPL+shear+convergence implemented (needs latest release version of lenstronomy)
May speed-up a bit the sampling of lenses and try-and-error calculations