### PR TITLE
simpler lens model for gamma=2 setting for speed up in that scenario

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 skypy
-lenstronomy>=1.11.9
+lenstronomy>=1.11.10
 astropy>=5.2
 numpy
 scipy

--- a/slsim/Deflectors/DeflectorTypes/epl_sersic.py
+++ b/slsim/Deflectors/DeflectorTypes/epl_sersic.py
@@ -73,7 +73,8 @@ class EPLSersic(DeflectorBase):
 
         :return: gamma (with =2 is isothermal)
         """
+
         try:
             return float(self._deflector_dict["gamma_pl"])
-        except:
+        except KeyError:
             return 2

--- a/slsim/Deflectors/DeflectorTypes/epl_sersic.py
+++ b/slsim/Deflectors/DeflectorTypes/epl_sersic.py
@@ -69,8 +69,11 @@ class EPLSersic(DeflectorBase):
 
     @property
     def halo_properties(self):
-        """Properties of the Halo (no halo is defined here)
+        """mass density logarithmic slope
 
-        :return: None
+        :return: gamma (with =2 is isothermal)
         """
-        return None
+        try:
+            return float(self._deflector_dict["gamma_pl"])
+        except:
+            return 2

--- a/slsim/Deflectors/elliptical_lens_galaxies.py
+++ b/slsim/Deflectors/elliptical_lens_galaxies.py
@@ -41,6 +41,8 @@ class EllipticalLensGalaxies(DeflectorsBase):
             galaxy_list["e2_mass"] = -np.ones(n)
         if "n_sersic" not in column_names:
             galaxy_list["n_sersic"] = -np.ones(n)
+        if "gamma_pl" not in column_names:
+            galaxy_list["gamma_pl"] = np.ones(n) * 2
 
         num_total = len(galaxy_list)
         z_min, z_max = 0, np.max(galaxy_list["z"])

--- a/slsim/Util/coolest_slsim_interface.py
+++ b/slsim/Util/coolest_slsim_interface.py
@@ -22,6 +22,8 @@ def update_coolest_from_slsim(
     :returns: saves updated .json file in a given path
     """
     kwargs_result_slsim = lens_class.lenstronomy_kwargs(band=band)[1]
+    # added gamma back as in simple version, a SIE is produced
+    kwargs_result_slsim["kwargs_lens"][0]["gamma"] = 2
 
     # Iterate over sources to extract magnitudes and convert to amplitudes
     source_amps = []

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -569,10 +569,7 @@ class Lens(LensedSystemBase):
         """
         if self.deflector.deflector_type in ["EPL"]:
             gamma = 2  # TODO: option for different power-law slopes to be implemented
-            if gamma == 2:
-                lens_mass_model_list = ["SIE"]
-            else:
-                lens_mass_model_list = ["EPL"]
+
             theta_E = self.einstein_radius_deflector
             e1_light_lens, e2_light_lens, e1_mass, e2_mass = (
                 self.deflector_ellipticity()
@@ -589,6 +586,12 @@ class Lens(LensedSystemBase):
                     "center_y": center_lens[1],
                 }
             ]
+            if gamma == 2:
+                lens_mass_model_list = ["SIE"]
+                kwargs_lens[0].pop("gamma")
+            else:
+                lens_mass_model_list = ["EPL"]
+
         elif self.deflector.deflector_type in ["NFW_HERNQUIST"]:
             lens_mass_model_list = ["NFW_ELLIPSE_CSE", "HERNQUIST_ELLIPSE_CSE"]
             e1_light_lens, e2_light_lens, e1_mass, e2_mass = (

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -568,8 +568,7 @@ class Lens(LensedSystemBase):
         :return: lens_model_list, kwargs_lens
         """
         if self.deflector.deflector_type in ["EPL"]:
-            gamma = 2  # TODO: option for different power-law slopes to be implemented
-
+            gamma = self.deflector.halo_properties
             theta_E = self.einstein_radius_deflector
             e1_light_lens, e2_light_lens, e1_mass, e2_mass = (
                 self.deflector_ellipticity()

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -568,7 +568,11 @@ class Lens(LensedSystemBase):
         :return: lens_model_list, kwargs_lens
         """
         if self.deflector.deflector_type in ["EPL"]:
-            lens_mass_model_list = ["EPL"]
+            gamma = 2  # TODO: option for different power-law slopes to be implemented
+            if gamma == 2:
+                lens_mass_model_list = ["SIE"]
+            else:
+                lens_mass_model_list = ["EPL"]
             theta_E = self.einstein_radius_deflector
             e1_light_lens, e2_light_lens, e1_mass, e2_mass = (
                 self.deflector_ellipticity()
@@ -578,7 +582,7 @@ class Lens(LensedSystemBase):
             kwargs_lens = [
                 {
                     "theta_E": theta_E,
-                    "gamma": 2,
+                    "gamma": gamma,
                     "e1": e1_mass,
                     "e2": e2_mass,
                     "center_x": center_lens[0],

--- a/tests/test_Deflectors/test_DeflectorTypes/test_epl_sersic.py
+++ b/tests/test_Deflectors/test_DeflectorTypes/test_epl_sersic.py
@@ -33,3 +33,7 @@ class TestEPLSersic(object):
     def test_velocity_dispersion(self):
         vel_disp = self.epl_sersic.velocity_dispersion()
         assert vel_disp == self.deflector_dict["vel_disp"]
+
+    def test_halo_porperties(self):
+        gamma = self.epl_sersic.halo_properties
+        assert gamma == 2

--- a/tests/test_coolest_slsim_interface.py
+++ b/tests/test_coolest_slsim_interface.py
@@ -54,6 +54,9 @@ def test_update_coolest_from_slsim_and_create_slsim_from_coolest(
     test_band = "i"
     test_mag_zero_point = 27
     expected_result = lens_class.lenstronomy_kwargs(band="i")
+    # current default is gamma=2 and hence an SIE profile is modeled instead
+    expected_result[0]["lens_model_list"][0] = "EPL"
+    expected_result[1]["kwargs_lens"][0]["gamma"] = 2
     # Call the function (this updates coolest file and saves in TestData)
     updated_coolest = update_coolest_from_slsim(
         lens_class, test_path, test_file_name, test_band, test_mag_zero_point

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -28,6 +28,10 @@ class TestLens(object):
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         self.source_dict = blue_one
         self.deflector_dict = red_one
+
+        print(blue_one)
+        blue_one["gamma_pl"] = 2.1
+
         while True:
             gg_lens = Lens(
                 source_dict=self.source_dict,


### PR DESCRIPTION
since current power-law slope is by default =2, in that setting using the SIE model is faster to compute

for power-law slope of gamma=2, by default the SIE model is called instead of the EPL model, which can speed up the calculations in that special case.
Unfortunately I had to hack a bit the coolest testing as only the EPL was meant to be tested.
A required lenstronomy update is also needed and the requirements.txt is updated.