### PR TITLE
bug fix about down-selected source number

### DIFF
--- a/slsim/Sources/galaxies.py
+++ b/slsim/Sources/galaxies.py
@@ -104,13 +104,21 @@ class Galaxies(SourcePopBase):
         self._num_select = len(self._galaxy_select)
         self.list_type = list_type
 
+    @property
     def source_number(self):
         """Number of sources registered (within given area on the sky)
 
         :return: number of sources
         """
-        number = self.n
-        return number
+        return self.n
+
+    @property
+    def source_number_selected(self):
+        """Number of sources selected (within given area on the sky)
+
+        :return: number of sources passing the selection criteria
+        """
+        return self._num_select
 
     def draw_source(self):
         """Choose source at random.

--- a/slsim/Sources/quasars.py
+++ b/slsim/Sources/quasars.py
@@ -51,6 +51,7 @@ class Quasars(SourcePopBase):
             kwargs_variability_model=kwargs_variability_model,
         )
 
+    @property
     def source_number(self):
         """Number of sources registered (within given area on the sky)
 
@@ -59,8 +60,16 @@ class Quasars(SourcePopBase):
         number = self.n
         return number
 
+    @property
+    def source_number_selected(self):
+        """Number of sources selected (within given area on the sky)
+
+        :return: number of sources passing the selection criteria
+        """
+        return self._num_select
+
     def draw_source(self):
-        """Choose source at random.
+        """Choose source at random with the selected range.
 
         :return: dictionary of source
         """

--- a/slsim/Sources/source_pop_base.py
+++ b/slsim/Sources/source_pop_base.py
@@ -27,11 +27,21 @@ class SourcePopBase(ABC):
         self._variab_model = variability_model
         self._kwargs_variab_model = kwargs_variability_model
 
+    @property
     @abstractmethod
     def source_number(self):
         """Number of sources registered (within given area on the sky)
 
         :return: number of sources
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def source_number_selected(self):
+        """Number of sources selected (within given area on the sky)
+
+        :return: number of sources passing the selection criteria
         """
         pass
 

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -272,6 +272,7 @@ class LensPop(LensedPopulationBase):
             if gg_lens.validity_test(**kwargs_lens_cut):
                 return gg_lens
 
+    @property
     def deflector_number(self):
         """Number of potential deflectors (meaning all objects with mass that are being
         considered to have potential sources behind them)
@@ -280,13 +281,14 @@ class LensPop(LensedPopulationBase):
         """
         return self._lens_galaxies.deflector_number()
 
+    @property
     def source_number(self):
         """Number of sources that are being considered to be placed in the sky area
         potentially aligned behind deflectors.
 
         :return: number of potential sources
         """
-        return self._sources.source_number()
+        return self._sources.source_number_selected
 
     def get_num_sources_tested_mean(self, testarea):
         """Compute the mean of source galaxies needed to be tested within the test area.
@@ -294,7 +296,7 @@ class LensPop(LensedPopulationBase):
         num_sources_tested_mean/ testarea = num_sources/ f_sky; testarea is in units of
         arcsec^2, f_sky is in units of deg^2. 1 deg^2 = 12960000 arcsec^2
         """
-        num_sources = self._sources.source_number()
+        num_sources = self._sources.source_number_selected
         num_sources_tested_mean = (testarea * num_sources) / (
             12960000 * self.f_sky.to_value("deg2")
         )

--- a/tests/test_Source/test_galaxies.py
+++ b/tests/test_Source/test_galaxies.py
@@ -275,7 +275,7 @@ class TestGalaxies(object):
         )
 
     def test_source_number(self):
-        number = self.galaxies.source_number()
+        number = self.galaxies.source_number
         assert number > 0
 
     def test_draw_source(self):

--- a/tests/test_Source/test_point_plus_extended_source.py
+++ b/tests/test_Source/test_point_plus_extended_source.py
@@ -24,7 +24,7 @@ class TestPointPlusExtendedSources(object):
         )
 
     def test_source_number(self):
-        number = self.pe_source.source_number()
+        number = self.pe_source.source_number
         assert number > 0
 
     def test_draw_source(self):

--- a/tests/test_Source/test_quasar.py
+++ b/tests/test_Source/test_quasar.py
@@ -36,6 +36,11 @@ def test_draw_source(Quasar_class):
     assert len(quasar) > 0
 
 
+def test_source_number_selected(Quasar_class):
+    num = Quasar_class.source_number_selected
+    assert num > 0
+
+
 def test_variability_model(Quasar_class):
     kwargs_variab = Quasar_class.variability_model
     assert kwargs_variab == "sinusoidal"

--- a/tests/test_Source/test_quasar.py
+++ b/tests/test_Source/test_quasar.py
@@ -27,7 +27,7 @@ def Quasar_class():
 
 
 def test_source_number(Quasar_class):
-    number = Quasar_class.source_number()
+    number = Quasar_class.source_number
     assert number > 0
 
 

--- a/tests/test_lens_pop.py
+++ b/tests/test_lens_pop.py
@@ -64,13 +64,13 @@ def test_supernovae_plus_galaxies_lens_pop_instance():
 
 
 def test_num_lenses_and_sources(gg_lens_pop_instance):
-    num_lenses = gg_lens_pop_instance.deflector_number()
-    num_sources = gg_lens_pop_instance.source_number()
+    num_lenses = gg_lens_pop_instance.deflector_number
+    num_sources = gg_lens_pop_instance.source_number
 
     assert 100 <= num_lenses <= 6600, "Expected num_lenses to be between 5800 and 6600,"
     f"but got {num_lenses}"
     assert (
-        100000 <= num_sources <= 500000
+        10000 <= num_sources <= 100000
     ), "Expected num_sources to be between 1090000 and"
     f"1110000, but got {num_sources}"
     # assert 1 == 0


### PR DESCRIPTION
This PR fixes a bug when down-selecting the source galaxy numbers, the strong lensing probability was computed on the total galaxy population while only being drawn from the down-selected one.
In addition I changed some definitions to property returns