### PR TITLE
Added lightcone integration of supernovae density

### DIFF
--- a/slsim/Sources/Supernovae/supernovae_lightcone.py
+++ b/slsim/Sources/Supernovae/supernovae_lightcone.py
@@ -27,20 +27,19 @@ class SNeLightcone(object):
         self._time_interval = time_interval
 
         sne_rate = SNIaRate(self._cosmo, self._input_redshifts[-1])
-        h = (self._cosmo.H(0).to_value()/100)
+        h = self._cosmo.H(0).to_value() / 100
 
         self.density = (
             self.convert_density(sne_rate.calculate_SNIa_rate(self._input_redshifts))
-            ) / h
+        ) / h
 
     def convert_density(self, density):
         """Converts SN Ia comoving densities from [yr^(-1)Mpc^(-3)] to have the desired
         time unit.
 
         :param density: initial comoving density of SN Ia [yr^(-1)Mpc^(-3)]
-
         :return: SN Ia comoving density with the desired time unit [day^(-1)Mpc^(-3),
-        hr^(-1)Mpc^(-3), etc.]
+            hr^(-1)Mpc^(-3), etc.]
         """
         time_conversion = (1 * units.year).to(self._time_interval.unit)
         converted_density = density / time_conversion * self._time_interval.value

--- a/slsim/Sources/Supernovae/supernovae_lightcone.py
+++ b/slsim/Sources/Supernovae/supernovae_lightcone.py
@@ -1,0 +1,72 @@
+from skypy.galaxies.redshift import redshifts_from_comoving_density
+from slsim.Sources.Supernovae.supernovae_pop import SNIaRate
+from astropy.table import Table
+from astropy import units
+
+
+class SNeLightcone(object):
+    """Class to integrate SNe comoving density n(z) in light cone volume."""
+
+    def __init__(self, cosmo, redshifts, sky_area, noise, time_interval):
+        """
+        :param cosmo: cosmology object
+        :type cosmo: ~astropy.cosmology object
+        :param redshifts: redshifts for supernovae density lightcone to be evaluated at
+        :type redshifts: array-like
+        :param sky_area: sky area for sampled galaxies in [solid angle]
+        :type sky_area: `~Astropy.units.Quantity`
+        :param noise: poisson-sample the number of galaxies in supernovae density lightcone
+        :type noise: bool
+        :param time_interval: time interval for supernovae density lightcone to be evaluated over
+        :type time_interval: `~Astropy.units.Quantity`
+        """
+        self._cosmo = cosmo
+        self._redshifts = redshifts
+        self._sky_area = sky_area
+        self._noise = noise
+        self._time_interval = time_interval
+
+        sne_rate = SNIaRate(self._cosmo, self._redshifts[-1])
+        self.density = self.convert_density(sne_rate.calculate_SNIa_rate(self._redshifts))
+
+    def convert_density(self, density):
+        """Converts SN Ia comoving densities from [yr^(-1)Mpc^(-3)] to have the desired time unit.
+
+        :param density: initial comoving density of SN Ia [yr^(-1)Mpc^(-3)]
+
+        :return: SN Ia comoving density with the desired time unit
+        [day^(-1)Mpc^(-3), hr^(-1)Mpc^(-3), etc.]
+        """
+        time_conversion = (1 * units.year).to(self._time_interval.unit)
+        converted_density = density / time_conversion * self._time_interval.value
+        return converted_density.value
+
+    def return_supernovae_sample(self):
+        """Integrates SNe comoving density in light cone.
+
+        :return: sampled redshifts such that the comoving number density of galaxies corresponds to
+        the input distribution
+        :return type: numpy.ndarray
+        """
+        redshift_list = redshifts_from_comoving_density(
+            redshift=self._redshifts,
+            density=self.density,
+            sky_area=self._sky_area,
+            cosmology=self._cosmo,
+            noise=self._noise,
+        )
+        return redshift_list
+
+    def redshift_table(self, redshift_list):
+        """Generates table with redshift locations of supernovae.
+
+        :param redshift_list: list of redshift locations of supernovae
+        :type redshift_lists: numpy.ndarray
+
+        :return: astropy table with redshift locations of supernovae
+        :return type: `~astropy.table.Table`
+        """
+        # Once lightcurve implementation is complete, it will be included here in the table
+        redshift_table = {'Redshift': []}
+        redshift_table['Redshift'].append(redshift_list)
+        return Table(redshift_table)

--- a/slsim/Sources/Supernovae/supernovae_lightcone.py
+++ b/slsim/Sources/Supernovae/supernovae_lightcone.py
@@ -27,15 +27,17 @@ class SNeLightcone(object):
         self._time_interval = time_interval
 
         sne_rate = SNIaRate(self._cosmo, self._redshifts[-1])
-        self.density = self.convert_density(sne_rate.calculate_SNIa_rate(self._redshifts))
+        self.density = self.convert_density(
+            sne_rate.calculate_SNIa_rate(self._redshifts)
+        )
 
     def convert_density(self, density):
-        """Converts SN Ia comoving densities from [yr^(-1)Mpc^(-3)] to have the desired time unit.
+        """Converts SN Ia comoving densities from [yr^(-1)Mpc^(-3)] to have the desired
+        time unit.
 
         :param density: initial comoving density of SN Ia [yr^(-1)Mpc^(-3)]
-
-        :return: SN Ia comoving density with the desired time unit
-        [day^(-1)Mpc^(-3), hr^(-1)Mpc^(-3), etc.]
+        :return: SN Ia comoving density with the desired time unit [day^(-1)Mpc^(-3),
+            hr^(-1)Mpc^(-3), etc.]
         """
         time_conversion = (1 * units.year).to(self._time_interval.unit)
         converted_density = density / time_conversion * self._time_interval.value
@@ -44,8 +46,8 @@ class SNeLightcone(object):
     def return_supernovae_sample(self):
         """Integrates SNe comoving density in light cone.
 
-        :return: sampled redshifts such that the comoving number density of galaxies corresponds to
-        the input distribution
+        :return: sampled redshifts such that the comoving number density of galaxies
+            corresponds to the input distribution
         :return type: numpy.ndarray
         """
         redshift_list = redshifts_from_comoving_density(
@@ -67,6 +69,6 @@ class SNeLightcone(object):
         :return type: `~astropy.table.Table`
         """
         # Once lightcurve implementation is complete, it will be included here in the table
-        redshift_table = {'Redshift': []}
-        redshift_table['Redshift'].append(redshift_list)
+        redshift_table = {"Redshift": []}
+        redshift_table["Redshift"].append(redshift_list)
         return Table(redshift_table)

--- a/slsim/Sources/Supernovae/supernovae_lightcone.py
+++ b/slsim/Sources/Supernovae/supernovae_lightcone.py
@@ -43,7 +43,7 @@ class SNeLightcone(object):
         converted_density = density / time_conversion * self._time_interval.value
         return converted_density.value
 
-    def return_supernovae_sample(self):
+    def supernovae_sample(self):
         """Integrates SNe comoving density in light cone.
 
         :return: sampled redshifts such that the comoving number density of galaxies
@@ -59,16 +59,14 @@ class SNeLightcone(object):
         )
         return redshift_list
 
-    def redshift_table(self, redshift_list):
+    def redshift_table(self):
         """Generates table with redshift locations of supernovae.
-
-        :param redshift_list: list of redshift locations of supernovae
-        :type redshift_lists: numpy.ndarray
 
         :return: astropy table with redshift locations of supernovae
         :return type: `~astropy.table.Table`
         """
         # Once lightcurve implementation is complete, it will be included here in the table
+        redshift_list = self.supernovae_sample()
         redshift_table = {"Redshift": []}
         redshift_table["Redshift"].append(redshift_list)
         return Table(redshift_table)

--- a/slsim/Sources/Supernovae/supernovae_pop.py
+++ b/slsim/Sources/Supernovae/supernovae_pop.py
@@ -21,7 +21,7 @@ def calculate_star_formation_rate(z):
 def delay_time_distribution(t_d):
     """Calculates the power-law constraint on time delay. (Eq 14 - Oguri and Marshall 2010)
 
-    :param t_d: time delay (t_d>=0)
+    :param t_d: time delay (t_d>=0) in [Gyr]
 
     :return: constrained time delay
     """

--- a/slsim/Sources/Supernovae/supernovae_pop.py
+++ b/slsim/Sources/Supernovae/supernovae_pop.py
@@ -54,7 +54,6 @@ class SNIaRate(object):
         """Calculates redshift given cosmic time.
 
         :param t: cosmic time since big bang in [Gy]
-
         :return: redshift at time t [float]
         """
         if not hasattr(self, "_age_inv"):

--- a/slsim/Sources/Supernovae/supernovae_pop.py
+++ b/slsim/Sources/Supernovae/supernovae_pop.py
@@ -11,6 +11,7 @@ def calculate_star_formation_rate(z):
     """Calculates the cosmic star formation rate. (Eq 13 - Oguri and Marshall 2010)
 
     :param z: redshift (z>=0)
+
     :return: cosmic star formation rate in [(h)(M_sol)yr^(-1)Mpc^(-3)]
     """
     star_formation_rate = (0.0118 + 0.08 * z) / (1 + (z / 3.3) ** 5.2)
@@ -20,14 +21,12 @@ def calculate_star_formation_rate(z):
 def delay_time_distribution(t_d):
     """Calculates the power-law constraint on time delay. (Eq 14 - Oguri and Marshall 2010)
 
-    :param t_d: time delay
+    :param t_d: time delay (t_d>=0)
+
     :return: constrained time delay
     """
-    if t_d > 0:
-        ft_d = (t_d) ** (-1.08)
-        return ft_d
-    else:
-        return np.nan
+    ft_d = (t_d) ** (-1.08)
+    return ft_d
 
 
 class SNIaRate(object):
@@ -55,8 +54,7 @@ class SNIaRate(object):
         """Calculates redshift given cosmic time.
 
         :param t: cosmic time since big bang in [Gy]
-        :param cosmo: cosmology object
-        :type cosmo: ~astropy.cosmology object
+
         :return: redshift at time t [float]
         """
         if not hasattr(self, "_age_inv"):
@@ -70,36 +68,35 @@ class SNIaRate(object):
         """Calculates the numerator integrand to be used within calculate_SNIa_rates.
         (Eq 15 - Oguri and Marshall 2010)
 
-        :param t_d: time delay
-        :param t: time at final integrated redshift
+        :param t_d: time delay (t>=0)
+        :param t: time at final integrated redshift (t>=0)
+
         :return: numerator integrand
         """
-        if t < 0 or t_d < 0:
-            return np.nan
-        else:
-            ft_d = delay_time_distribution(t_d)
-            z_t = self.z_from_time(t - t_d)  # time since big bang
-            return calculate_star_formation_rate(z_t) * ft_d
+        ft_d = delay_time_distribution(t_d)
+        z_t = self.z_from_time(t - t_d)  # time since big bang
+        return calculate_star_formation_rate(z_t) * ft_d
 
     def calculate_SNIa_rate(self, z, eta=0.04):
         """Calculates the rate of SN Ia. (Eq 15 - Oguri and Marshall 2010)
 
-        :param z: redshift
+        :param z: redshift (z>=0)
         :param eta: canonical efficiency
-        :param cosmo: cosmology object
-        :type cosmo: ~astropy.cosmology object
+
         :return: SN Ia rate n(z) in [(h)yr^(-1)Mpc^(-3)]
+        :return type: array-like
         """
-        if z < 0:
-            return np.nan
-        else:
-            C_Ia = 0.032
-            t_z = self._cosmo.age(z).to_value()  # Time at given redshift z
+        C_Ia = 0.032
+        denominator = self._denominator
+        SNIa_rate_list = []
+
+        for i in z:
+            t_z = self._cosmo.age(i).to_value()  # Time at given redshift z
 
             numerator = integrate.quad(
                 self._numerator_integrand, 0.1, t_z - self._t_min, args=(t_z,)
             )
-            denominator = self._denominator
-
             SNIa_rate = eta * C_Ia * (numerator[0] / denominator[0])
-            return SNIa_rate
+            SNIa_rate_list.append(SNIa_rate)
+
+        return np.array(SNIa_rate_list)

--- a/tests/test_Source/test_supernovae_lightcone.py
+++ b/tests/test_Source/test_supernovae_lightcone.py
@@ -38,7 +38,7 @@ class TestSNeLightcone:
         )
         test_density = self.sne_lightcone.density[0]
         npt.assert_almost_equal(
-            test_density, ((4.10996270e-05 / 365.25) * 2), decimal=4
+            test_density, ((5.87137528e-05 / 365.25) * 2), decimal=4
         )
 
         self.time_interval = 1 * units.year
@@ -50,7 +50,7 @@ class TestSNeLightcone:
             time_interval=self.time_interval,
         )
         test_density = self.sne_lightcone.density[0]
-        npt.assert_almost_equal(test_density, 4.1099626976289775e-05, decimal=4)
+        npt.assert_almost_equal(test_density, 5.87137528e-05, decimal=4)
 
     def test_return_supernovae_sample(self):
         # Observed SN Ia redshift locations using return_supernovae_sample()

--- a/tests/test_Source/test_supernovae_lightcone.py
+++ b/tests/test_Source/test_supernovae_lightcone.py
@@ -54,7 +54,7 @@ class TestSNeLightcone:
 
     def test_return_supernovae_sample(self):
         # Observed SN Ia redshift locations using return_supernovae_sample()
-        sample_output = self.sne_lightcone.return_supernovae_sample()
+        sample_output = self.sne_lightcone.supernovae_sample()
 
         # Observed counts using Lightcone()
         observed_counts, bin_edges = np.histogram(
@@ -84,9 +84,7 @@ class TestSNeLightcone:
         assert p_value > 0.05, f"KS Test failed: p-value = {p_value}"
 
     def test_redshift_table(self):
-        random_redshift_array = np.random.uniform(0, 10, 10)
-
-        table = self.sne_lightcone.redshift_table(random_redshift_array)
+        table = self.sne_lightcone.redshift_table()
         assert isinstance(table, Table), "Generated table is not an Astropy Table"
 
 

--- a/tests/test_Source/test_supernovae_lightcone.py
+++ b/tests/test_Source/test_supernovae_lightcone.py
@@ -1,0 +1,90 @@
+from slsim.Sources.Supernovae.supernovae_lightcone import SNeLightcone
+from astropy.cosmology import FlatLambdaCDM
+from astropy.units import Quantity
+from scipy.stats import ks_2samp
+from astropy.table import Table
+import numpy as np
+from astropy import units
+import numpy.testing as npt
+import pytest
+
+
+class TestSNeLightcone():
+    def setup_method(self):
+        self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        self.redshifts = np.linspace(0, 5, 20)
+        self.sky_area = Quantity(value=0.05, unit="deg2")
+        self.noise = False
+        self.time_interval = 1 * units.year
+
+        self.sne_lightcone = SNeLightcone(
+            cosmo=self.cosmo,
+            redshifts=self.redshifts,
+            sky_area=self.sky_area,
+            noise=self.noise,
+            time_interval=self.time_interval
+        )
+
+    def test_convert_density(self):
+        npt.assert_(isinstance(self.time_interval, units.Quantity))
+
+        self.time_interval = 2 * units.day
+        self.sne_lightcone = SNeLightcone(
+            cosmo=self.cosmo,
+            redshifts=self.redshifts,
+            sky_area=self.sky_area,
+            noise=self.noise,
+            time_interval=self.time_interval
+        )
+        test_density = self.sne_lightcone.density[0]
+        npt.assert_almost_equal(test_density, ((4.10996270e-05/365.25)*2), decimal=4)
+
+        self.time_interval = 1 * units.year
+        self.sne_lightcone = SNeLightcone(
+            cosmo=self.cosmo,
+            redshifts=self.redshifts,
+            sky_area=self.sky_area,
+            noise=self.noise,
+            time_interval=self.time_interval
+        )
+        test_density = self.sne_lightcone.density[0]
+        npt.assert_almost_equal(test_density, 4.1099626976289775e-05, decimal=4)
+
+    def test_return_supernovae_sample(self):
+        # Observed SN Ia redshift locations using return_supernovae_sample()
+        sample_output = self.sne_lightcone.return_supernovae_sample()
+
+        # Observed counts using Lightcone()
+        observed_counts, bin_edges = np.histogram(sample_output, bins=self.redshifts, density=True)
+
+        # Expected counts based SN Ia comoving density
+        dN_dz = (
+            self.cosmo.differential_comoving_volume(self.redshifts) * self.sky_area
+        ).to_value('Mpc3')
+        dN_dz *= self.sne_lightcone.density
+        bin_widths = np.diff(self.redshifts)
+        expected_counts = dN_dz[:-1] * bin_widths
+
+        # Normalize expected counts
+        expected_counts *= len(sample_output) / np.sum(expected_counts)
+
+        # KS test to compare observed and expected distributions
+        observed_cdf = np.cumsum(observed_counts)
+        observed_cdf /= observed_cdf[-1]
+
+        expected_cdf = np.cumsum(expected_counts)
+        expected_cdf /= expected_cdf[-1]
+
+        _, p_value = ks_2samp(observed_cdf, expected_cdf)
+
+        assert p_value > 0.05, f"KS Test failed: p-value = {p_value}"
+
+    def test_redshift_table(self):
+        random_redshift_array = np.random.uniform(0, 10, 10)
+
+        table = self.sne_lightcone.redshift_table(random_redshift_array)
+        assert isinstance(table, Table), "Generated table is not an Astropy Table"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_Source/test_supernovae_lightcone.py
+++ b/tests/test_Source/test_supernovae_lightcone.py
@@ -9,7 +9,7 @@ import numpy.testing as npt
 import pytest
 
 
-class TestSNeLightcone():
+class TestSNeLightcone:
     def setup_method(self):
         self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         self.redshifts = np.linspace(0, 5, 20)
@@ -22,7 +22,7 @@ class TestSNeLightcone():
             redshifts=self.redshifts,
             sky_area=self.sky_area,
             noise=self.noise,
-            time_interval=self.time_interval
+            time_interval=self.time_interval,
         )
 
     def test_convert_density(self):
@@ -34,10 +34,12 @@ class TestSNeLightcone():
             redshifts=self.redshifts,
             sky_area=self.sky_area,
             noise=self.noise,
-            time_interval=self.time_interval
+            time_interval=self.time_interval,
         )
         test_density = self.sne_lightcone.density[0]
-        npt.assert_almost_equal(test_density, ((4.10996270e-05/365.25)*2), decimal=4)
+        npt.assert_almost_equal(
+            test_density, ((4.10996270e-05 / 365.25) * 2), decimal=4
+        )
 
         self.time_interval = 1 * units.year
         self.sne_lightcone = SNeLightcone(
@@ -45,7 +47,7 @@ class TestSNeLightcone():
             redshifts=self.redshifts,
             sky_area=self.sky_area,
             noise=self.noise,
-            time_interval=self.time_interval
+            time_interval=self.time_interval,
         )
         test_density = self.sne_lightcone.density[0]
         npt.assert_almost_equal(test_density, 4.1099626976289775e-05, decimal=4)
@@ -55,12 +57,14 @@ class TestSNeLightcone():
         sample_output = self.sne_lightcone.return_supernovae_sample()
 
         # Observed counts using Lightcone()
-        observed_counts, bin_edges = np.histogram(sample_output, bins=self.redshifts, density=True)
+        observed_counts, bin_edges = np.histogram(
+            sample_output, bins=self.redshifts, density=True
+        )
 
         # Expected counts based SN Ia comoving density
         dN_dz = (
             self.cosmo.differential_comoving_volume(self.redshifts) * self.sky_area
-        ).to_value('Mpc3')
+        ).to_value("Mpc3")
         dN_dz *= self.sne_lightcone.density
         bin_widths = np.diff(self.redshifts)
         expected_counts = dN_dz[:-1] * bin_widths

--- a/tests/test_Source/test_supernovae_pop.py
+++ b/tests/test_Source/test_supernovae_pop.py
@@ -22,7 +22,7 @@ def test_delay_time_distribution():
     npt.assert_almost_equal(delay_time_distribution(t_d), 5 ** (-1.08), decimal=4)
 
 
-class TestSNIaRate():
+class TestSNIaRate:
     def setup_method(self):
         self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         self.z_max = 10
@@ -60,21 +60,13 @@ class TestSNIaRate():
 
     def test_calculate_SNIa_rate(self):
         # (Fig 2 - Oguri and Marshall 2010)
-        z_array = ([0, 1, 2, 3])
+        z_array = [0, 1, 2, 3]
         rate_array = self.sne_rate.calculate_SNIa_rate(z_array)
 
-        npt.assert_almost_equal(
-            rate_array[0], 0.000041006, decimal=3
-        )
-        npt.assert_almost_equal(
-            rate_array[1], 0.0001191, decimal=3
-        )
-        npt.assert_almost_equal(
-            rate_array[2], 0.0001349, decimal=3
-        )
-        npt.assert_almost_equal(
-            rate_array[3], 0.00008008, decimal=3
-        )
+        npt.assert_almost_equal(rate_array[0], 0.000041006, decimal=3)
+        npt.assert_almost_equal(rate_array[1], 0.0001191, decimal=3)
+        npt.assert_almost_equal(rate_array[2], 0.0001349, decimal=3)
+        npt.assert_almost_equal(rate_array[3], 0.00008008, decimal=3)
 
 
 if __name__ == "__main__":

--- a/tests/test_Source/test_supernovae_pop.py
+++ b/tests/test_Source/test_supernovae_pop.py
@@ -4,8 +4,8 @@ from slsim.Sources.Supernovae.supernovae_pop import (
 )
 from slsim.Sources.Supernovae.supernovae_pop import SNIaRate
 from astropy.cosmology import FlatLambdaCDM
-import numpy as np
 import numpy.testing as npt
+import pytest
 
 
 def test_calculate_star_formation_rate():
@@ -16,13 +16,13 @@ def test_calculate_star_formation_rate():
 
 
 def test_delay_time_distribution():
-    t_d = -1
-    npt.assert_equal(delay_time_distribution(t_d), np.nan)
+    t_d = 2
+    npt.assert_almost_equal(delay_time_distribution(t_d), 2 ** (-1.08), decimal=4)
     t_d = 5
     npt.assert_almost_equal(delay_time_distribution(t_d), 5 ** (-1.08), decimal=4)
 
 
-class TestSNIaRate:
+class TestSNIaRate():
     def setup_method(self):
         self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         self.z_max = 10
@@ -53,32 +53,29 @@ class TestSNIaRate:
         npt.assert_almost_equal(z_est, z_true, decimal=3)
 
     def test_numerator_integrand(self):
-        t_d, t = -1, 1
-        npt.assert_equal(self.sne_rate._numerator_integrand(t_d, t), np.nan)
-        t_d, t = 1, -1
-        npt.assert_equal(self.sne_rate._numerator_integrand(t_d, t), np.nan)
         t_d, t = 1, 1
         npt.assert_almost_equal(
             self.sne_rate._numerator_integrand(t_d, t), 0.0002559, decimal=4
         )
 
     def test_calculate_SNIa_rate(self):
-        z = -1
-        npt.assert_equal(self.sne_rate.calculate_SNIa_rate(z), np.nan)
         # (Fig 2 - Oguri and Marshall 2010)
-        z = 0
+        z_array = ([0, 1, 2, 3])
+        rate_array = self.sne_rate.calculate_SNIa_rate(z_array)
+
         npt.assert_almost_equal(
-            self.sne_rate.calculate_SNIa_rate(z), 0.000041006, decimal=3
+            rate_array[0], 0.000041006, decimal=3
         )
-        z = 1
         npt.assert_almost_equal(
-            self.sne_rate.calculate_SNIa_rate(z), 0.0001191, decimal=3
+            rate_array[1], 0.0001191, decimal=3
         )
-        z = 2
         npt.assert_almost_equal(
-            self.sne_rate.calculate_SNIa_rate(z), 0.0001349, decimal=3
+            rate_array[2], 0.0001349, decimal=3
         )
-        z = 3
         npt.assert_almost_equal(
-            self.sne_rate.calculate_SNIa_rate(z), 0.00008008, decimal=3
+            rate_array[3], 0.00008008, decimal=3
         )
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
- Added SNeLightcone class in `supernovae_lightcone.py`
  - Utilizes skypy function `redshifts_from_comoving_density` to obtain an array of supernovae redshift locations from SNe comoving density
  - Allows user to pick the time interval and redshift range over which the lightcone is evaluated
  - Can output the redshifts as an astropy table
- Added corresponding TestSNeLightcone class in `test_supernovae_lightcone.py`
- Updated `supernovae_pop.py` to allow array-like inputs to facilitate SNeLightcone class 
- Updated corresponding `test_supernovae_pop.py`