### PR TITLE
Increased Speed of draw_population

### DIFF
--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -443,8 +443,8 @@ class LensPop(LensedPopulationBase):
         implement a version of it. (improve the algorithm)
 
         :param kwargs_lens_cuts: validity test keywords
-        :param speed_factor: factor by which the number of deflectors is decreased to speed up
-        the calculations
+        :param speed_factor: factor by which the number of deflectors is decreased to
+            speed up the calculations
         :type kwargs_lens_cuts: dict
         :return: List of Lens instances with parameters of the deflectors and lens and
             source light.
@@ -462,10 +462,12 @@ class LensPop(LensedPopulationBase):
         #        print(np.int(num_lenses * num_sources_tested_mean))
 
         # Draw a population of galaxy-galaxy lenses within the area.
-        for _ in range(int(num_lenses/speed_factor)):
+        for _ in range(int(num_lenses / speed_factor)):
             lens = self._lens_galaxies.draw_deflector()
             test_area = draw_test_area(deflector=lens)
-            num_sources_tested = self.get_num_sources_tested(testarea=test_area*speed_factor)
+            num_sources_tested = self.get_num_sources_tested(
+                testarea=test_area * speed_factor
+            )
             # TODO: to implement this for a multi-source plane lens system
             if num_sources_tested > 0:
                 n = 0

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -438,11 +438,13 @@ class LensPop(LensedPopulationBase):
         num_sources_range = np.random.poisson(lam=num_sources_tested_mean)
         return num_sources_range
 
-    def draw_population(self, kwargs_lens_cuts):
+    def draw_population(self, speed_factor, kwargs_lens_cuts):
         """Return full population list of all lenses within the area # TODO: need to
         implement a version of it. (improve the algorithm)
 
         :param kwargs_lens_cuts: validity test keywords
+        :param speed_factor: factor by which the number of deflectors is decreased to speed up
+        the calculations
         :type kwargs_lens_cuts: dict
         :return: List of Lens instances with parameters of the deflectors and lens and
             source light.
@@ -460,10 +462,10 @@ class LensPop(LensedPopulationBase):
         #        print(np.int(num_lenses * num_sources_tested_mean))
 
         # Draw a population of galaxy-galaxy lenses within the area.
-        for _ in range(num_lenses):
+        for _ in range(int(num_lenses/speed_factor)):
             lens = self._lens_galaxies.draw_deflector()
             test_area = draw_test_area(deflector=lens)
-            num_sources_tested = self.get_num_sources_tested(testarea=test_area)
+            num_sources_tested = self.get_num_sources_tested(testarea=test_area*speed_factor)
             # TODO: to implement this for a multi-source plane lens system
             if num_sources_tested > 0:
                 n = 0

--- a/tests/test_lens_pop.py
+++ b/tests/test_lens_pop.py
@@ -173,10 +173,16 @@ def test_supernovae_lens_pop_instance():
     kwargs_lens_cuts = {}
     # drawing population
     pes_lens_population = pes_lens_pop.draw_population(
-        kwargs_lens_cuts=kwargs_lens_cuts
+        1, kwargs_lens_cuts=kwargs_lens_cuts
+    )
+    pes_lens_population_speed = pes_lens_pop.draw_population(
+        10, kwargs_lens_cuts=kwargs_lens_cuts
     )
     pes_lens_population2 = pes_lens_pop2.draw_population(
-        kwargs_lens_cuts=kwargs_lens_cuts
+        1, kwargs_lens_cuts=kwargs_lens_cuts
+    )
+    pes_lens_population2_speed = pes_lens_pop2.draw_population(
+        100, kwargs_lens_cuts=kwargs_lens_cuts
     )
     kwargs_lens_cut = {}
     pes_lens_class = pes_lens_pop.select_lens_at_random(**kwargs_lens_cut)
@@ -184,6 +190,7 @@ def test_supernovae_lens_pop_instance():
     assert "z" in pes_lens_class.source.source_dict.colnames
     assert len(pes_lens_class.source.source_dict) == 1
     assert abs(len(pes_lens_population) - len(pes_lens_population2)) <= 12
+    assert abs(len(pes_lens_population_speed) - len(pes_lens_population2_speed)) <= 12
 
 
 def test_num_lenses_and_sources(gg_lens_pop_instance):


### PR DESCRIPTION
- Added speed_parameter to draw_population in LensPop to decrease the number of deflectors drawn and speed up the calculation (test_area is then increased proportionally to account for this change)
- Added test case for the function.