### PR TITLE
Updated scipy dependence to account for deprecated function (temporary fix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ skypy
 lenstronomy>=1.11.10
 astropy>=5.2
 numpy
-scipy
+scipy<=1.13.1
 colossus
 speclite
 pyyaml


### PR DESCRIPTION
Your branch is up to date with 'origin/main'.

Changes to be committed:
	modified:   requirements.txt

Speclite hasn't updated after scipy deprecated integrate.trapz -> this fixes errors caused by this. 
Will need to update this once speclite updates their code.

This addressed issue #200 