### PR TITLE
Fixed some typo and changed some code for consistency.

### DIFF
--- a/slsim/Sources/QuasarCatalog/quasar_pop.py
+++ b/slsim/Sources/QuasarCatalog/quasar_pop.py
@@ -131,7 +131,9 @@ class QuasarRate(object):
 
     def dPhi_dM(self, M, z_value):
         """Calculates dPhi_dM for a given M and redshift according to Eq (10) in Oguri &
-        Marshall (2010): DOI: 10.1111/j.1365-2966.2010.16639.x.
+        Marshall (2010): DOI: 10.1111/j.1365-2966.2010.16639.x. The (1 + z)^-3 factor 
+        converts from physical to comoving volume to account for the expansion of the 
+        universe.
 
         :param M: Absolute i-band magnitude.
         :type M: float or numpy.ndarray
@@ -163,7 +165,7 @@ class QuasarRate(object):
             where=denominator_dphi_dm != 0,
         )
 
-        return term1
+        return term1/((1 + z_value) ** 3) ## Convert from physical to wanted comoving volume.
 
     def convert_magnitude(self, magnitude, z, conversion="apparent_to_absolute"):
         """Converts between apparent and absolute magnitudes using K-corrections
@@ -196,10 +198,7 @@ class QuasarRate(object):
 
     def n_comoving(self, m_min, m_max, z_value):
         """Calculates the comoving number density of quasars by integrating dPhi/dM over
-        the range of absolute magnitudes and applying the (1 + z)^-3 factor.
-
-        The (1 + z)^-3 factor converts from physical to comoving number density to
-        account for the expansion of the universe and scale factor a = (1 + z)^-1.
+        the range of absolute magnitudes.
 
         :param m_min: Minimum apparent magnitude.
         :type m_min: float or np.ndarray
@@ -221,16 +220,11 @@ class QuasarRate(object):
             integrals = np.zeros_like(z_value)
             for i, z in enumerate(z_value):
                 integral, _ = quad(self.dPhi_dM, M_min[i], M_max[i], args=(z,))
-                integrals[i] = (
-                    integral / (1 + z) ** 3
-                )  # Convert from physical to wanted comoving density
+                integrals[i] = integral
             return integrals
         else:
             integral, _ = quad(self.dPhi_dM, M_min, M_max, args=(z_value,))
-            return (
-                integral / (1 + z_value) ** 3
-            )  # Convert from physical to wanted comoving density
-
+            return integral
     def generate_quasar_redshifts(self, m_min, m_max):
         """Generates redshift locations of quasars using a light cone formulation.
 

--- a/slsim/Sources/Supernovae/supernovae_lightcone.py
+++ b/slsim/Sources/Supernovae/supernovae_lightcone.py
@@ -30,8 +30,8 @@ class SNeLightcone(object):
 
         # Account for included factor of h and convert the density from physical to comoving
         self.density = (
-            self.convert_density(sne_rate.calculate_SNIa_rate(self._input_redshifts))
-        ) / (h * (1 + self._input_redshifts) ** 3)
+            self.convert_density(sne_rate.calculate_SNIa_rate(self._input_redshifts)*h)
+        ) / ((1 + self._input_redshifts) ** 3)
 
     def convert_density(self, density):
         """Converts SN Ia comoving densities from [yr^(-1)Mpc^(-3)] to have the desired


### PR DESCRIPTION
This PR fixes a typo in the SNIa number density. Additionally, in the quasar case, the physical-to-comoving volume factor was placed in the luminosity function and removed from the density. The density is derived from the luminosity function, so this factor consistently applies to the density.