### PR TITLE
 Refactoring SLSim - Simplify LensPop

### DIFF
--- a/slsim/Deflectors/__init__.py
+++ b/slsim/Deflectors/__init__.py
@@ -1,5 +1,7 @@
-from .all_lens_galaxies import AllLensGalaxies
-from .compound_lens_halos_galaxies import CompoundLensHalosGalaxies
-from .elliptical_lens_galaxies import EllipticalLensGalaxies
-from .deflector import Deflector
-from .deflectors_base import DeflectorsBase
+from .all_lens_galaxies import AllLensGalaxies as AllLensGalaxies
+from .compound_lens_halos_galaxies import (
+    CompoundLensHalosGalaxies as CompoundLensHalosGalaxies,
+)
+from .elliptical_lens_galaxies import EllipticalLensGalaxies as EllipticalLensGalaxies
+from .deflector import Deflector as Deflector
+from .deflectors_base import DeflectorsBase as DeflectorsBase

--- a/slsim/Deflectors/__init__.py
+++ b/slsim/Deflectors/__init__.py
@@ -1,7 +1,13 @@
-from .all_lens_galaxies import AllLensGalaxies as AllLensGalaxies
-from .compound_lens_halos_galaxies import (
-    CompoundLensHalosGalaxies as CompoundLensHalosGalaxies,
-)
-from .elliptical_lens_galaxies import EllipticalLensGalaxies as EllipticalLensGalaxies
-from .deflector import Deflector as Deflector
-from .deflectors_base import DeflectorsBase as DeflectorsBase
+from .all_lens_galaxies import *
+from .compound_lens_halos_galaxies import *
+from .elliptical_lens_galaxies import *
+from .deflector import *
+from .deflectors_base import *
+
+# from .all_lens_galaxies import AllLensGalaxies as AllLensGalaxies
+# from .compound_lens_halos_galaxies import (
+#     CompoundLensHalosGalaxies as CompoundLensHalosGalaxies,
+# )
+# from .elliptical_lens_galaxies import EllipticalLensGalaxies as EllipticalLensGalaxies
+# from .deflector import Deflector as Deflector
+# from .deflectors_base import DeflectorsBase as DeflectorsBase

--- a/slsim/Deflectors/__init__.py
+++ b/slsim/Deflectors/__init__.py
@@ -1,13 +1,13 @@
-from .all_lens_galaxies import *
-from .compound_lens_halos_galaxies import *
-from .elliptical_lens_galaxies import *
-from .deflector import *
-from .deflectors_base import *
+from .all_lens_galaxies import AllLensGalaxies
+from .compound_lens_halos_galaxies import CompoundLensHalosGalaxies
+from .elliptical_lens_galaxies import EllipticalLensGalaxies
+from .deflector import Deflector
+from .deflectors_base import DeflectorsBase
 
-# from .all_lens_galaxies import AllLensGalaxies as AllLensGalaxies
-# from .compound_lens_halos_galaxies import (
-#     CompoundLensHalosGalaxies as CompoundLensHalosGalaxies,
-# )
-# from .elliptical_lens_galaxies import EllipticalLensGalaxies as EllipticalLensGalaxies
-# from .deflector import Deflector as Deflector
-# from .deflectors_base import DeflectorsBase as DeflectorsBase
+__all__ = [
+    "AllLensGalaxies",
+    "CompoundLensHalosGalaxies",
+    "EllipticalLensGalaxies",
+    "Deflector",
+    "DeflectorsBase",
+]

--- a/slsim/Deflectors/__init__.py
+++ b/slsim/Deflectors/__init__.py
@@ -1,0 +1,5 @@
+from .all_lens_galaxies import AllLensGalaxies
+from .compound_lens_halos_galaxies import CompoundLensHalosGalaxies
+from .elliptical_lens_galaxies import EllipticalLensGalaxies
+from .deflector import Deflector
+from .deflectors_base import DeflectorsBase

--- a/slsim/Pipelines/__init__.py
+++ b/slsim/Pipelines/__init__.py
@@ -1,3 +1,3 @@
-from .halos_pipeline import HalosSkyPyPipeline
-from .skypy_pipeline import SkyPyPipeline
-from .sl_hammocks_pipeline import SLHammocksPipeline
+from .halos_pipeline import HalosSkyPyPipeline as HalosSkyPyPipeline
+from .skypy_pipeline import SkyPyPipeline as SkyPyPipeline
+from .sl_hammocks_pipeline import SLHammocksPipeline as SLHammocksPipeline

--- a/slsim/Pipelines/__init__.py
+++ b/slsim/Pipelines/__init__.py
@@ -1,3 +1,9 @@
-from .halos_pipeline import HalosSkyPyPipeline as HalosSkyPyPipeline
-from .skypy_pipeline import SkyPyPipeline as SkyPyPipeline
-from .sl_hammocks_pipeline import SLHammocksPipeline as SLHammocksPipeline
+from .halos_pipeline import HalosSkyPyPipeline
+from .skypy_pipeline import SkyPyPipeline
+from .sl_hammocks_pipeline import SLHammocksPipeline
+
+__all__ = [
+    "HalosSkyPyPipeline",
+    "SkyPyPipeline",
+    "SLHammocksPipeline",
+]

--- a/slsim/Pipelines/__init__.py
+++ b/slsim/Pipelines/__init__.py
@@ -1,0 +1,3 @@
+from .halos_pipeline import HalosSkyPyPipeline
+from .skypy_pipeline import SkyPyPipeline
+from .sl_hammocks_pipeline import SLHammocksPipeline

--- a/slsim/Sources/QuasarCatalog/__init__.py
+++ b/slsim/Sources/QuasarCatalog/__init__.py
@@ -1,1 +1,3 @@
-from .quasar_plus_galaxies import quasar_galaxies_simple as quasar_galaxies_simple
+from .quasar_plus_galaxies import quasar_galaxies_simple
+
+__all__ = ["quasar_galaxies_simple"]

--- a/slsim/Sources/QuasarCatalog/__init__.py
+++ b/slsim/Sources/QuasarCatalog/__init__.py
@@ -1,0 +1,1 @@
+from .quasar_plus_galaxies import quasar_galaxies_simple as quasar_galaxies_simple

--- a/slsim/Sources/SupernovaeCatalog/__init__.py
+++ b/slsim/Sources/SupernovaeCatalog/__init__.py
@@ -1,0 +1,1 @@
+from .supernovae_sample import SupernovaeCatalog as SupernovaeCatalog

--- a/slsim/Sources/SupernovaeCatalog/__init__.py
+++ b/slsim/Sources/SupernovaeCatalog/__init__.py
@@ -1,1 +1,3 @@
-from .supernovae_sample import SupernovaeCatalog as SupernovaeCatalog
+from .supernovae_sample import SupernovaeCatalog
+
+__all__ = ["SupernovaeCatalog"]

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -4,3 +4,4 @@ from .point_plus_extended_sources import (
     PointPlusExtendedSources as PointPlusExtendedSources,
 )
 from . import QuasarCatalog as QuasarCatalog
+from . import SupernovaeCatalog as SupernovaeCatalog

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -1,0 +1,3 @@
+from .galaxies import Galaxies
+from .point_sources import PointSources
+from .point_plus_extended_sources import PointPlusExtendedSources

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -3,3 +3,4 @@ from .point_sources import PointSources as PointSources
 from .point_plus_extended_sources import (
     PointPlusExtendedSources as PointPlusExtendedSources,
 )
+import QuasarCatalog as QuasarCatalog

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -1,3 +1,5 @@
-from .galaxies import Galaxies
-from .point_sources import PointSources
-from .point_plus_extended_sources import PointPlusExtendedSources
+from .galaxies import Galaxies as Galaxies
+from .point_sources import PointSources as PointSources
+from .point_plus_extended_sources import (
+    PointPlusExtendedSources as PointPlusExtendedSources,
+)

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -3,4 +3,4 @@ from .point_sources import PointSources as PointSources
 from .point_plus_extended_sources import (
     PointPlusExtendedSources as PointPlusExtendedSources,
 )
-import QuasarCatalog as QuasarCatalog
+from . import QuasarCatalog as QuasarCatalog

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -1,7 +1,13 @@
-from .galaxies import Galaxies as Galaxies
-from .point_sources import PointSources as PointSources
-from .point_plus_extended_sources import (
-    PointPlusExtendedSources as PointPlusExtendedSources,
-)
-from . import QuasarCatalog as QuasarCatalog
-from . import SupernovaeCatalog as SupernovaeCatalog
+from .galaxies import Galaxies
+from .point_sources import PointSources
+from .point_plus_extended_sources import PointPlusExtendedSources
+from . import QuasarCatalog
+from . import SupernovaeCatalog
+
+__all__ = [
+    "Galaxies",
+    "PointSources",
+    "PointPlusExtendedSources",
+    "QuasarCatalog",
+    "SupernovaeCatalog",
+]

--- a/slsim/Sources/galaxies.py
+++ b/slsim/Sources/galaxies.py
@@ -40,6 +40,7 @@ class Galaxies(SourcePopBase):
         :type catalog_type: str. eg: "scotch" or None
         """
         super(Galaxies, self).__init__(cosmo=cosmo, sky_area=sky_area)
+        self.source_type = "extended"
         self.n = len(galaxy_list)
         self.light_profile = light_profile
         # add missing keywords in astropy.Table object

--- a/slsim/Sources/galaxies.py
+++ b/slsim/Sources/galaxies.py
@@ -8,6 +8,7 @@ from slsim.Util.param_util import average_angular_size, axis_ratio, eccentricity
 from lenstronomy.Util import constants
 
 
+# TODO: Use type to determine galaxy_list type
 class Galaxies(SourcePopBase):
     """Class describing elliptical galaxies."""
 

--- a/slsim/Sources/point_plus_extended_sources.py
+++ b/slsim/Sources/point_plus_extended_sources.py
@@ -61,3 +61,4 @@ class PointPlusExtendedSources(Galaxies, SourcePopBase):
         SourcePopBase.__init__(
             self, cosmo, sky_area, variability_model, kwargs_variability_model
         )
+        self.source_type = "point_plus_extended"

--- a/slsim/Sources/point_sources.py
+++ b/slsim/Sources/point_sources.py
@@ -44,7 +44,7 @@ class PointSources(SourcePopBase):
         :param list_type: type of the format of the source catalog. It should be either
          astropy_table or list of astropy table.
         """
-        self.source_type = "point"
+
         self.n = len(point_source_list)
         self.light_profile = light_profile
         if self.light_profile is not None:
@@ -65,6 +65,7 @@ class PointSources(SourcePopBase):
             variability_model=variability_model,
             kwargs_variability_model=kwargs_variability_model,
         )
+        self.source_type = "point_source"
 
     @property
     def source_number(self):

--- a/slsim/Sources/point_sources.py
+++ b/slsim/Sources/point_sources.py
@@ -44,6 +44,7 @@ class PointSources(SourcePopBase):
         :param list_type: type of the format of the source catalog. It should be either
          astropy_table or list of astropy table.
         """
+        self.source_type = "point"
         self.n = len(point_source_list)
         self.light_profile = light_profile
         if self.light_profile is not None:

--- a/slsim/Sources/source_pop_base.py
+++ b/slsim/Sources/source_pop_base.py
@@ -23,8 +23,8 @@ class SourcePopBase(ABC):
          the individual sources.
         """
         self.source_type = None
+        self.sky_area = sky_area
         self._cosmo = cosmo
-        self._sky_area = sky_area
         self._variab_model = variability_model
         self._kwargs_variab_model = kwargs_variability_model
 

--- a/slsim/Sources/source_pop_base.py
+++ b/slsim/Sources/source_pop_base.py
@@ -22,6 +22,7 @@ class SourcePopBase(ABC):
          a source. This is a population argument, not the light curve parameter for
          the individual sources.
         """
+        self.source_type = None
         self._cosmo = cosmo
         self._sky_area = sky_area
         self._variab_model = variability_model

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -47,13 +47,13 @@ class LensPop(LensedPopulationBase):
         """
 
         super().__init__(
-            cosmo,
-            lightcurve_time,
-            sn_type,
-            sn_absolute_mag_band,
-            sn_absolute_zpsys,
-            sn_modeldir,
             sky_area=None,
+            cosmo=cosmo,
+            lightcurve_time=lightcurve_time,
+            sn_type=sn_type,
+            sn_absolute_mag_band=sn_absolute_mag_band,
+            sn_absolute_zpsys=sn_absolute_zpsys,
+            sn_modeldir=sn_modeldir,
         )
         self.cosmo = cosmo
         self._lens_galaxies = deflector_population
@@ -64,7 +64,7 @@ class LensPop(LensedPopulationBase):
         ) / self._sources._sky_area.to_value("deg2")
         self._factor_deflector = self.f_sky.to_value(
             "deg2"
-        ) / self._lens_galaxies._sky_area.to_value("deg2")
+        ) / self._lens_galaxies.sky_area.to_value("deg2")
         self.los_config = los_config
         if self.los_config is None:
             self.los_config = LOSConfig()

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -19,6 +19,7 @@ class LensPop(LensedPopulationBase):
         deflector_population: DeflectorsBase,
         source_population: SourcePopBase,
         cosmo: Optional[Cosmology] = None,
+        sky_area: Optional[float] = None,
         lightcurve_time: Optional[np.ndarray] = None,
         sn_type: Optional[str] = None,
         sn_absolute_mag_band: Optional[Union[str, sncosmo.Bandpass]] = None,
@@ -47,7 +48,7 @@ class LensPop(LensedPopulationBase):
         """
 
         super().__init__(
-            sky_area=None,
+            sky_area=sky_area,
             cosmo=cosmo,
             lightcurve_time=lightcurve_time,
             sn_type=sn_type,
@@ -59,10 +60,10 @@ class LensPop(LensedPopulationBase):
         self._lens_galaxies = deflector_population
         self._sources = source_population
 
-        self._factor_source = self.f_sky.to_value(
+        self._factor_source = self.sky_area.to_value(
             "deg2"
         ) / self._sources.sky_area.to_value("deg2")
-        self._factor_deflector = self.f_sky.to_value(
+        self._factor_deflector = self.sky_area.to_value(
             "deg2"
         ) / self._lens_galaxies.sky_area.to_value("deg2")
         self.los_config = los_config
@@ -121,7 +122,7 @@ class LensPop(LensedPopulationBase):
     def get_num_sources_tested_mean(self, testarea):
         """Compute the mean of source galaxies needed to be tested within the test area.
 
-        num_sources_tested_mean/ testarea = num_sources/ f_sky; testarea is in units of
+        num_sources_tested_mean/ testarea = num_sources/ sky_area; testarea is in units of
         arcsec^2, f_sky is in units of deg^2. 1 deg^2 = 12960000 arcsec^2
         """
         num_sources = self.source_number

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -126,7 +126,7 @@ class LensPop(LensedPopulationBase):
         """
         num_sources = self.source_number
         num_sources_tested_mean = (testarea * num_sources) / (
-            12960000 * self._factor_source * self.source_sky_area.to_value("deg2")
+            12960000 * self._factor_source * self._sources._sky_area.to_value("deg2")
         )
         return num_sources_tested_mean
 

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -47,6 +47,7 @@ class LensPop(LensedPopulationBase):
                                                    please look at the documentation of RandomizedSupernovae class. Defaults to None.
         """
 
+        # TODO: ADD EXCEPTION FOR DEFLECTOR AND SOURCE POP FILTER MISMATCH
         super().__init__(
             sky_area=sky_area,
             cosmo=cosmo,

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -61,7 +61,7 @@ class LensPop(LensedPopulationBase):
 
         self._factor_source = self.f_sky.to_value(
             "deg2"
-        ) / self._sources._sky_area.to_value("deg2")
+        ) / self._sources.sky_area.to_value("deg2")
         self._factor_deflector = self.f_sky.to_value(
             "deg2"
         ) / self._lens_galaxies.sky_area.to_value("deg2")
@@ -126,7 +126,7 @@ class LensPop(LensedPopulationBase):
         """
         num_sources = self.source_number
         num_sources_tested_mean = (testarea * num_sources) / (
-            12960000 * self._factor_source * self._sources._sky_area.to_value("deg2")
+            12960000 * self._factor_source * self._sources.sky_area.to_value("deg2")
         )
         return num_sources_tested_mean
 

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -183,7 +183,7 @@ class LensPop(LensedPopulationBase):
                         sn_absolute_zpsys=self.sn_absolute_zpsys,
                         cosmo=self.cosmo,
                         test_area=test_area,
-                        source_type=self._source_model_type,
+                        source_type=self._sources.source_type,
                         los_config=self.los_config,
                         light_profile=self._sources.light_profile,
                         lightcurve_time=self.lightcurve_time,

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -91,7 +91,7 @@ class LensPop(LensedPopulationBase):
                 sn_absolute_mag_band=self.sn_absolute_mag_band,
                 sn_absolute_zpsys=self.sn_absolute_zpsys,
                 cosmo=self.cosmo,
-                source_type=self._source_model_type,
+                source_type=self._sources.source_type,
                 light_profile=self._sources.light_profile,
                 lightcurve_time=self.lightcurve_time,
                 los_config=self.los_config,

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -1,42 +1,14 @@
-import astropy.cosmology
-from slsim.ParamDistributions.los_config import LOSConfig
-import os
-import pickle
-import astropy
 import sncosmo
-
 import numpy as np
-from astropy.table import Table
-from typing import Optional, Union
 
 from slsim.lens import Lens
+from typing import Optional, Union
+from astropy.cosmology import Cosmology
 from slsim.lens import theta_e_when_source_infinity
-from slsim.lensed_population_base import LensedPopulationBase
-from slsim.Pipelines.skypy_pipeline import SkyPyPipeline
-from slsim.Deflectors.deflectors_base import DeflectorsBase
 from slsim.Sources.source_pop_base import SourcePopBase
-
-# """
-# :param cosmo: cosmology object
-# :type cosmo: `~astropy.cosmology.FLRW`
-# :param lightcurve_time: observation time array for lightcurve in unit of days.
-# :type lightcurve_time: array
-# :param sn_type: Supernova type (Ia, Ib, Ic, IIP, etc.)
-# :type sn_type: str
-# :param sn_absolute_mag_band: Band used to normalize to absolute magnitude
-# :type sn_absolute_mag_band: str or `~sncosmo.Bandpass`
-# :param sn_absolute_zpsys: Optional, AB or Vega (AB default)
-# :type sn_absolute_zpsys: str
-# :param los_config: configuration for line of sight distribution
-# :type los_config: LOSConfig instance
-# :param sn_modeldir: sn_modeldir is the path to the directory containing files
-#     needed to initialize the sncosmo.model class. For example,
-#     sn_modeldir = 'C:/Users/username/Documents/SALT3.NIR_WAVEEXT'. These data can
-#     be downloaded from https://github.com/LSST-strong-lensing/data_public .
-#     For more detail, please look at the documentation of RandomizedSupernovae
-#     class.
-# :type sn_modeldir: str
-# """
+from slsim.ParamDistributions.los_config import LOSConfig
+from slsim.Deflectors.deflectors_base import DeflectorsBase
+from slsim.lensed_population_base import LensedPopulationBase
 
 
 class LensPop(LensedPopulationBase):
@@ -46,7 +18,7 @@ class LensPop(LensedPopulationBase):
         self,
         deflector_population: DeflectorsBase,
         source_population: SourcePopBase,
-        cosmo: Optional[astropy.cosmology.Cosmology] = None,
+        cosmo: Optional[Cosmology] = None,
         lightcurve_time: Optional[np.ndarray] = None,
         sn_type: Optional[str] = None,
         sn_absolute_mag_band: Optional[Union[str, sncosmo.Bandpass]] = None,
@@ -58,8 +30,8 @@ class LensPop(LensedPopulationBase):
         Args:
             deflector_population (DeflectorsBase): Deflector population as an instance of a DeflectorsBase subclass.
             source_population (SourcePopBase): Source population as an instance of a SourcePopBase subclass
-            cosmo (Optional[astropy.cosmology.Cosmology], optional): AstroPy Cosmology instance. If None, defaults to flat LCDM
-                                                                     with h0=0.7 and Om0=0.3. Defaults to None.
+            cosmo (Optional[Cosmology], optional): AstroPy Cosmology instance. If None, defaults to flat LCDM with h0=0.7 and Om0=0.3.
+                                                   Defaults to None.
             lightcurve_time (Optional[np.ndarray], optional): Lightcurve observation time array in units of days. Defaults to None.
             sn_type (Optional[str], optional): Supernova type (Ia, Ib, Ic, IIP, etc.). Defaults to None.
             sn_absolute_mag_band (Optional[Union[str,sncosmo.Bandpass]], optional): Band used to normalize to absolute magnitude.

--- a/slsim/lensed_population_base.py
+++ b/slsim/lensed_population_base.py
@@ -51,7 +51,7 @@ class LensedPopulationBase(ABC):
 
             sky_area = Quantity(value=0.1, unit="deg2")
             warnings.warn("No sky area provided, instead uses 0.1 deg2")
-        self.f_sky = sky_area
+        self.sky_area = sky_area
 
         if cosmo is None:
             warnings.warn(

--- a/tests/test_lens_pop.py
+++ b/tests/test_lens_pop.py
@@ -1,4 +1,7 @@
+import os
 import pytest
+import slsim
+import pickle
 
 import numpy as np
 import slsim.Sources as sources
@@ -106,15 +109,37 @@ def test_galaxies_lens_pop_halo_model_instance():
     kwargs_deflector_cut = {"z_min": 0.001, "z_max": 2.5}
     kwargs_source_cut = {"band": "g", "band_max": 28, "z_min": 0.1, "z_max": 5.0}
 
-    g_lens_halo_model_pop = LensPop(
-        deflector_type="halo-models",
-        source_type="galaxies",
-        kwargs_deflector_cut=kwargs_deflector_cut,
-        kwargs_source_cut=kwargs_source_cut,
-        kwargs_mass2light=None,
-        skypy_config=None,
+    halo_galaxy_simulation_pipeline = pipelines.SLHammocksPipeline(
         slhammocks_config=None,
         sky_area=sky_area,
+        cosmo=cosmo,
+    )
+
+    galaxy_simulation_pipeline = pipelines.SkyPyPipeline(
+        skypy_config=None,
+        sky_area=sky_area,
+        filters=None,
+    )
+
+    lens_galaxies = deflectors.CompoundLensHalosGalaxies(
+        halo_galaxy_list=halo_galaxy_simulation_pipeline._pipeline,
+        kwargs_cut=kwargs_deflector_cut,
+        kwargs_mass2light={},
+        cosmo=cosmo,
+        sky_area=sky_area,
+    )
+
+    source_galaxies = sources.Galaxies(
+        galaxy_list=galaxy_simulation_pipeline.blue_galaxies,
+        kwargs_cut=kwargs_source_cut,
+        cosmo=cosmo,
+        sky_area=sky_area,
+        catalog_type="skypy",
+    )
+
+    g_lens_halo_model_pop = LensPop(
+        deflector_population=lens_galaxies,
+        source_population=source_galaxies,
         cosmo=cosmo,
     )
     assert g_lens_halo_model_pop._lens_galaxies.draw_deflector()["halo_mass"] != 0
@@ -123,19 +148,45 @@ def test_galaxies_lens_pop_halo_model_instance():
 def test_supernovae_plus_galaxies_lens_pop_instance():
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
     sky_area = Quantity(value=0.001, unit="deg2")
+
     kwargs_deflector_cut = {"band": "g", "band_max": 23, "z_min": 0.01, "z_max": 2.5}
     kwargs_source_cut = {"z_min": 0.1, "z_max": 5.0}
-    pes_lens_pop = LensPop(
-        deflector_type="all-galaxies",
-        source_type="supernovae_plus_galaxies",
-        kwargs_deflector_cut=kwargs_deflector_cut,
-        kwargs_source_cut=kwargs_source_cut,
-        variability_model="light_curve",
-        kwargs_variability={"MJD", "ps_mag_r"},
-        kwargs_mass2light=None,
+
+    galaxy_simulation_pipeline = pipelines.SkyPyPipeline(
         skypy_config=None,
         sky_area=sky_area,
-        catalog_type="supernovae_sample",
+        filters=None,
+    )
+
+    lens_galaxies = deflectors.AllLensGalaxies(
+        red_galaxy_list=galaxy_simulation_pipeline.red_galaxies,
+        blue_galaxy_list=galaxy_simulation_pipeline.blue_galaxies,
+        kwargs_cut=kwargs_deflector_cut,
+        kwargs_mass2light={},
+        cosmo=cosmo,
+        sky_area=sky_area,
+    )
+
+    path = (
+        os.path.dirname(slsim.__file__)
+        + "/Sources/SupernovaeCatalog/supernovae_data.pkl"
+    )
+    with open(path, "rb") as f:
+        supernovae_data = pickle.load(f)
+
+    source_galaxies = sources.PointPlusExtendedSources(
+        point_plus_extended_sources_list=supernovae_data,
+        cosmo=cosmo,
+        sky_area=sky_area,
+        kwargs_cut=kwargs_source_cut,
+        variability_model="light_curve",
+        kwargs_variability_model={"MJD", "ps_mag_r"},
+        list_type="list",
+    )
+
+    pes_lens_pop = LensPop(
+        deflector_population=lens_galaxies,
+        source_population=source_galaxies,
         cosmo=cosmo,
     )
     kwargs_lens_cut = {}
@@ -146,28 +197,61 @@ def test_supernovae_plus_galaxies_lens_pop_instance():
 def test_supernovae_plus_galaxies_lens_pop_instance_2():
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
     sky_area = Quantity(value=0.3, unit="deg2")
-    sky_area1 = Quantity(value=0.1, unit="deg2")
-    sky_area2 = Quantity(value=0.2, unit="deg2")
+    deflector_sky_area = Quantity(value=0.1, unit="deg2")
+    source_sky_area = Quantity(value=0.2, unit="deg2")
+
     kwargs_deflector_cut = {"band": "g", "band_max": 23, "z_min": 0.01, "z_max": 2.5}
     kwargs_source_cut = {"z_min": 0.1, "z_max": 5.0}
+
     time_range = np.linspace(-20, 50, 500)
-    pes_lens_pop = LensPop(
-        deflector_type="all-galaxies",
-        source_type="supernovae_plus_galaxies",
-        kwargs_deflector_cut=kwargs_deflector_cut,
-        kwargs_source_cut=kwargs_source_cut,
+
+    galaxy_simulation_pipeline = pipelines.SkyPyPipeline(
+        skypy_config=None,
+        sky_area=deflector_sky_area,
+        filters=None,
+    )
+
+    lens_galaxies = deflectors.AllLensGalaxies(
+        red_galaxy_list=galaxy_simulation_pipeline.red_galaxies,
+        blue_galaxy_list=galaxy_simulation_pipeline.blue_galaxies,
+        kwargs_cut=kwargs_deflector_cut,
+        kwargs_mass2light={},
+        cosmo=cosmo,
+        sky_area=deflector_sky_area,
+    )
+
+    supernovae_catalog = sources.SupernovaeCatalog.SupernovaeCatalog(
+        sn_type="Ia",
+        band_list=["i"],
+        lightcurve_time=time_range,
+        absolute_mag_band="bessellb",
+        absolute_mag=None,
+        mag_zpsys="ab",
+        cosmo=cosmo,
+        skypy_config=None,
+        sky_area=source_sky_area,
+    )
+    supernovae_data = supernovae_catalog.supernovae_catalog(
+        host_galaxy=True, lightcurve=False
+    )
+
+    source_galaxies = sources.PointPlusExtendedSources(
+        point_plus_extended_sources_list=supernovae_data,
+        cosmo=cosmo,
+        sky_area=source_sky_area,
+        kwargs_cut=kwargs_source_cut,
         variability_model="light_curve",
-        kwargs_variability={"supernovae_lightcurve", "i"},
+        kwargs_variability_model={"supernovae_lightcurve", "i"},
+    )
+
+    pes_lens_pop = LensPop(
+        deflector_population=lens_galaxies,
+        source_population=source_galaxies,
+        cosmo=cosmo,
+        lightcurve_time=time_range,
         sn_type="Ia",
         sn_absolute_mag_band="bessellb",
         sn_absolute_zpsys="ab",
-        kwargs_mass2light=None,
-        skypy_config=None,
-        sky_area=sky_area,
-        source_sky_area=sky_area2,
-        deflector_sky_area=sky_area1,
-        cosmo=cosmo,
-        lightcurve_time=time_range,
     )
     kwargs_lens_cut = {}
     pes_lens_class = pes_lens_pop.select_lens_at_random(**kwargs_lens_cut)
@@ -176,72 +260,133 @@ def test_supernovae_plus_galaxies_lens_pop_instance_2():
     assert len(
         pes_lens_class.source.kwargs_variability_extracted["i"]["ps_mag_i"]
     ) == len(time_range)
-    assert pes_lens_pop.source_sky_area != pes_lens_pop.deflector_sky_area
 
 
 def test_supernovae_lens_pop_instance():
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-    sky_area = Quantity(value=3, unit="deg2")
-    sky_area2 = Quantity(value=1, unit="deg2")
+    sky_area_1 = Quantity(value=3, unit="deg2")
+    sky_area_2 = Quantity(value=1, unit="deg2")
+
     kwargs_deflector_cut = {"band": "g", "band_max": 23, "z_min": 0.01, "z_max": 2.5}
     kwargs_source_cut = {"z_min": 0.1, "z_max": 5.0}
+
     time_range = np.linspace(-20, 50, 500)
-    pes_lens_pop = LensPop(
-        deflector_type="elliptical",
-        source_type="supernovae",
-        kwargs_deflector_cut=kwargs_deflector_cut,
-        kwargs_source_cut=kwargs_source_cut,
+
+    galaxy_simulation_pipeline_1 = pipelines.SkyPyPipeline(
+        skypy_config=None,
+        sky_area=sky_area_1,
+        filters=None,
+    )
+    lens_galaxies_1 = deflectors.EllipticalLensGalaxies(
+        galaxy_list=galaxy_simulation_pipeline_1.red_galaxies,
+        kwargs_cut=kwargs_deflector_cut,
+        kwargs_mass2light={},
+        cosmo=cosmo,
+        sky_area=sky_area_1,
+    )
+
+    galaxy_simulation_pipeline_2 = pipelines.SkyPyPipeline(
+        skypy_config=None,
+        sky_area=sky_area_2,
+        filters=None,
+    )
+    lens_galaxies_2 = deflectors.EllipticalLensGalaxies(
+        galaxy_list=galaxy_simulation_pipeline_2.red_galaxies,
+        kwargs_cut=kwargs_deflector_cut,
+        kwargs_mass2light={},
+        cosmo=cosmo,
+        sky_area=sky_area_2,
+    )
+
+    supernovae_catalog_1 = sources.SupernovaeCatalog.SupernovaeCatalog(
+        sn_type="Ia",
+        band_list=["r"],
+        lightcurve_time=time_range,
+        absolute_mag_band="bessellb",
+        absolute_mag=None,
+        mag_zpsys="ab",
+        cosmo=cosmo,
+        skypy_config=None,
+        sky_area=sky_area_1,
+    )
+    supernovae_data_1 = supernovae_catalog_1.supernovae_catalog(
+        host_galaxy=False, lightcurve=False
+    )
+
+    supernovae_catalog_2 = sources.SupernovaeCatalog.SupernovaeCatalog(
+        sn_type="Ia",
+        band_list=["r"],
+        lightcurve_time=time_range,
+        absolute_mag_band="bessellb",
+        absolute_mag=None,
+        mag_zpsys="ab",
+        cosmo=cosmo,
+        skypy_config=None,
+        sky_area=sky_area_2,
+    )
+    supernovae_data_2 = supernovae_catalog_2.supernovae_catalog(
+        host_galaxy=False, lightcurve=False
+    )
+
+    source_galaxies_1 = sources.PointSources(
+        point_source_list=supernovae_data_1,
+        cosmo=cosmo,
+        sky_area=sky_area_1,
+        kwargs_cut=kwargs_source_cut,
         variability_model="light_curve",
-        kwargs_variability={"supernovae_lightcurve", "r"},
+        kwargs_variability_model={"supernovae_lightcurve", "r"},
+    )
+
+    source_galaxies_2 = sources.PointSources(
+        point_source_list=supernovae_data_2,
+        cosmo=cosmo,
+        sky_area=sky_area_2,
+        kwargs_cut=kwargs_source_cut,
+        variability_model="light_curve",
+        kwargs_variability_model={"supernovae_lightcurve", "r"},
+    )
+
+    ps_lens_pop_1 = LensPop(
+        deflector_population=lens_galaxies_1,
+        source_population=source_galaxies_1,
+        cosmo=cosmo,
+        lightcurve_time=time_range,
         sn_type="Ia",
         sn_absolute_mag_band="bessellb",
         sn_absolute_zpsys="ab",
-        kwargs_mass2light=None,
-        skypy_config=None,
-        sky_area=sky_area,
+    )
+
+    ps_lens_pop_2 = LensPop(
+        deflector_population=lens_galaxies_2,
+        source_population=source_galaxies_2,
         cosmo=cosmo,
         lightcurve_time=time_range,
-    )
-    large_skyarea = Quantity(value=3, unit="deg2")
-    pes_lens_pop2 = LensPop(
-        deflector_type="elliptical",
-        source_type="supernovae",
-        kwargs_deflector_cut=kwargs_deflector_cut,
-        kwargs_source_cut=kwargs_source_cut,
-        variability_model="light_curve",
-        kwargs_variability={"supernovae_lightcurve", "r"},
         sn_type="Ia",
         sn_absolute_mag_band="bessellb",
         sn_absolute_zpsys="ab",
-        kwargs_mass2light=None,
-        skypy_config=None,
-        source_sky_area=sky_area2,
-        deflector_sky_area=sky_area2,
-        sky_area=large_skyarea,
-        cosmo=cosmo,
-        lightcurve_time=time_range,
     )
-    kwargs_lens_cuts = {}
+
     # drawing population
-    pes_lens_population = pes_lens_pop.draw_population(
+    kwargs_lens_cuts = {}
+    ps_lens_population_1 = ps_lens_pop_1.draw_population(
         speed_factor=1, kwargs_lens_cuts=kwargs_lens_cuts
     )
-    pes_lens_population_speed = pes_lens_pop.draw_population(
+    ps_lens_population_1_speed = ps_lens_pop_1.draw_population(
         speed_factor=10, kwargs_lens_cuts=kwargs_lens_cuts
     )
-    pes_lens_population2 = pes_lens_pop2.draw_population(
+    ps_lens_population_2 = ps_lens_pop_2.draw_population(
         speed_factor=1, kwargs_lens_cuts=kwargs_lens_cuts
     )
-    pes_lens_population2_speed = pes_lens_pop2.draw_population(
+    ps_lens_population_2_speed = ps_lens_pop_2.draw_population(
         speed_factor=100, kwargs_lens_cuts=kwargs_lens_cuts
     )
     kwargs_lens_cut = {}
-    pes_lens_class = pes_lens_pop.select_lens_at_random(**kwargs_lens_cut)
-    assert pes_lens_class._source_type == "point_source"
-    assert "z" in pes_lens_class.source.source_dict.colnames
-    assert len(pes_lens_class.source.source_dict) == 1
-    assert abs(len(pes_lens_population) - len(pes_lens_population2)) <= 12
-    assert abs(len(pes_lens_population_speed) - len(pes_lens_population2_speed)) <= 12
+    ps_lens_class = ps_lens_pop_1.select_lens_at_random(**kwargs_lens_cut)
+    assert ps_lens_class._source_type == "point_source"
+    assert "z" in ps_lens_class.source.source_dict.colnames
+    assert len(ps_lens_class.source.source_dict) == 1
+    assert abs(len(ps_lens_population_1) - len(ps_lens_population_2)) <= 12
+    assert abs(len(ps_lens_population_1_speed) - len(ps_lens_population_2_speed)) <= 12
 
 
 def test_num_lenses_and_sources(gg_lens_pop_instance):

--- a/tests/test_lens_pop.py
+++ b/tests/test_lens_pop.py
@@ -196,7 +196,6 @@ def test_supernovae_plus_galaxies_lens_pop_instance():
 
 def test_supernovae_plus_galaxies_lens_pop_instance_2():
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-    sky_area = Quantity(value=0.3, unit="deg2")
     deflector_sky_area = Quantity(value=0.1, unit="deg2")
     source_sky_area = Quantity(value=0.2, unit="deg2")
 


### PR DESCRIPTION
WIP pull request for #224 . 

## To-Do List

- [x] Move `SkyPyPipeline` out of `LensPop`.
- [x] Move instances of `_lens_galaxies` attribute (i.e instances of `DeflectorBase` subclasses) out of `LensPop` and instead expect as input to `LensPop`.
- [x] Move instances of `_sources` attribute (i.e instances of `SourcePopBase`) out of `LensPop` and instead expect as input to `LensPop`.
- [x] Update unit tests.
- [ ] Update tutorials to reflect changes.