### PR TITLE
Allows for initialization of Source or Lens class using dicts instead of astropy tables

### DIFF
--- a/slsim/Sources/source.py
+++ b/slsim/Sources/source.py
@@ -56,13 +56,18 @@ class Source(object):
         # Convert dict to astropy table
         if isinstance(source_dict, dict):
             self.source_dict = Table([source_dict])[0]
-        else: #if source_dict is already an astropy table
+        else:  # if source_dict is already an astropy table
             self.source_dict = source_dict
 
         # If center_x and center_y are already specified, use them instead of picking randomly
-        if 'center_x' in self.source_dict.colnames and 'center_y' in self.source_dict.colnames:
-            self._center_source = np.array([self.source_dict['center_x'], self.source_dict['center_y']])
-        
+        if (
+            "center_x" in self.source_dict.colnames
+            and "center_y" in self.source_dict.colnames
+        ):
+            self._center_source = np.array(
+                [self.source_dict["center_x"], self.source_dict["center_y"]]
+            )
+
         self.variability_model = variability_model
         self.kwargs_variability = kwargs_variability
         self.sn_type = sn_type

--- a/slsim/Sources/source.py
+++ b/slsim/Sources/source.py
@@ -27,7 +27,7 @@ class Source(object):
     ):
         """
         :param source_dict: Source properties
-        :type source_dict: dict
+        :type source_dict: dict or astropy table
         :param variability_model: keyword for variability model to be used. This is an
          input for the Variability class.
         :type variability_model: str
@@ -52,7 +52,17 @@ class Source(object):
          class.
         :type sn_modeldir: str
         """
-        self.source_dict = source_dict
+
+        # Convert dict to astropy table
+        if isinstance(source_dict, dict):
+            self.source_dict = Table([source_dict])[0]
+        else: #if source_dict is already an astropy table
+            self.source_dict = source_dict
+
+        # If center_x and center_y are already specified, use them instead of picking randomly
+        if 'center_x' in self.source_dict.colnames and 'center_y' in self.source_dict.colnames:
+            self._center_source = np.array([self.source_dict['center_x'], self.source_dict['center_y']])
+        
         self.variability_model = variability_model
         self.kwargs_variability = kwargs_variability
         self.sn_type = sn_type

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -48,7 +48,7 @@ class Lens(LensedSystemBase):
         """
 
         :param source_dict: source properties
-        :type source_dict: dict
+        :type source_dict: dict or astropy table
         :param deflector_dict: deflector properties
         :type deflector_dict: dict
         :param cosmo: astropy.cosmology instance

--- a/slsim/lensed_system_base.py
+++ b/slsim/lensed_system_base.py
@@ -26,7 +26,7 @@ class LensedSystemBase(ABC):
     ):
         """
         :param source_dict: source properties
-        :type source_dict: dict
+        :type source_dict: dict or astropy table
         :param deflector_dict: deflector properties
         :type deflector_dict: dict
         :param deflector_type: type of deflector, i.e. "EPL", "NFW_HERNQUIST"

--- a/tests/test_Source/test_source.py
+++ b/tests/test_Source/test_source.py
@@ -143,6 +143,16 @@ class TestSource:
                 "dec_off",
             ),
         )
+        self.source_dict5 = {'angular_size': 0.1651633078964498,
+                            'center_x': 0.30298310338567075,
+                            'center_y': -0.3505004565139597,
+                            'e1': 0.06350855238708408,
+                            'e2': -0.08420760408362458,
+                            'mag_F106': 21.434711611915137,
+                            'mag_F129': 21.121205893763328,
+                            'mag_F184': 20.542431041034558,
+                            'n_sersic': 1.0,
+                            'z': 3.123}
 
         self.source = Source(
             self.source_dict,
@@ -221,9 +231,14 @@ class TestSource:
             lightcurve_time=np.linspace(-20, 50, 100),
             cosmo=None,
         )
+        self.source11 = Source(
+            self.source_dict5,
+            cosmo=cosmo
+        )
 
     def test_redshift(self):
         assert self.source.redshift == [0.5]
+        assert self.source11.redshift == 3.123
 
     def test_n_sersic(self):
         assert self.source.n_sersic == [4]
@@ -305,6 +320,18 @@ class TestSource:
         )
         assert len(kwargs) == 1
         assert isinstance(kwargs[0], dict)
+
+        kwargs_source11 = self.source11.kwargs_extended_source_light(
+            center_lens, draw_area, band="F106"
+        )
+        kwargs_source11_ref = [{'R_sersic': 0.1651633078964498,
+                    'center_x': 0.30298310338567075,
+                    'center_y': -0.3505004565139597,
+                    'e1': -0.06350855238708408,
+                    'e2': -0.08420760408362458,
+                    'magnitude': 21.434711611915137,
+                    'n_sersic': 1.0}]
+        assert kwargs_source11 == kwargs_source11_ref
 
     def test_kwargs_extended_source_light_double_sersic(self):
         center_lens = np.array([0, 0])

--- a/tests/test_Source/test_source.py
+++ b/tests/test_Source/test_source.py
@@ -143,16 +143,18 @@ class TestSource:
                 "dec_off",
             ),
         )
-        self.source_dict5 = {'angular_size': 0.1651633078964498,
-                            'center_x': 0.30298310338567075,
-                            'center_y': -0.3505004565139597,
-                            'e1': 0.06350855238708408,
-                            'e2': -0.08420760408362458,
-                            'mag_F106': 21.434711611915137,
-                            'mag_F129': 21.121205893763328,
-                            'mag_F184': 20.542431041034558,
-                            'n_sersic': 1.0,
-                            'z': 3.123}
+        self.source_dict5 = {
+            "angular_size": 0.1651633078964498,
+            "center_x": 0.30298310338567075,
+            "center_y": -0.3505004565139597,
+            "e1": 0.06350855238708408,
+            "e2": -0.08420760408362458,
+            "mag_F106": 21.434711611915137,
+            "mag_F129": 21.121205893763328,
+            "mag_F184": 20.542431041034558,
+            "n_sersic": 1.0,
+            "z": 3.123,
+        }
 
         self.source = Source(
             self.source_dict,
@@ -231,10 +233,7 @@ class TestSource:
             lightcurve_time=np.linspace(-20, 50, 100),
             cosmo=None,
         )
-        self.source11 = Source(
-            self.source_dict5,
-            cosmo=cosmo
-        )
+        self.source11 = Source(self.source_dict5, cosmo=cosmo)
 
     def test_redshift(self):
         assert self.source.redshift == [0.5]
@@ -324,13 +323,17 @@ class TestSource:
         kwargs_source11 = self.source11.kwargs_extended_source_light(
             center_lens, draw_area, band="F106"
         )
-        kwargs_source11_ref = [{'R_sersic': 0.1651633078964498,
-                    'center_x': 0.30298310338567075,
-                    'center_y': -0.3505004565139597,
-                    'e1': -0.06350855238708408,
-                    'e2': -0.08420760408362458,
-                    'magnitude': 21.434711611915137,
-                    'n_sersic': 1.0}]
+        kwargs_source11_ref = [
+            {
+                "R_sersic": 0.1651633078964498,
+                "center_x": 0.30298310338567075,
+                "center_y": -0.3505004565139597,
+                "e1": -0.06350855238708408,
+                "e2": -0.08420760408362458,
+                "magnitude": 21.434711611915137,
+                "n_sersic": 1.0,
+            }
+        ]
         assert kwargs_source11 == kwargs_source11_ref
 
     def test_kwargs_extended_source_light_double_sersic(self):


### PR DESCRIPTION
Previously, in order to create an instance of the Lens class, the source_dict parameter needed to be an astropy table (the documentation was also incorrect as a consequence). This PR allows for source_dict to be a dict by converting the dict into an astropy table during the initialization of the class.

Additionally, if the user wants to initialize a Lens or Source class with a specific center_x and center_y, they can now do so by specifying them in source_dict.