### PR TITLE
Removed automatic psf normalization in roman_image_simulation

### DIFF
--- a/slsim/roman_image_simulation.py
+++ b/slsim/roman_image_simulation.py
@@ -207,10 +207,10 @@ def get_psf(band, detector, detector_pos, oversample, psf_directory):
         wfi.detector_position = detector_pos
         psf = wfi.calc_psf(oversample=oversample)
 
-    # import PSF to GalSim (and normalize the PSF so that sum.psf = 1)
+    # import PSF to GalSim
     oversampled_pixel_scale = 0.11 / oversample
     psf_image = galsim.Image(
-        psf[0].data / np.sum(psf[0].data), scale=oversampled_pixel_scale
+        psf[0].data, scale=oversampled_pixel_scale
     )
 
     return galsim.InterpolatedImage(psf_image)

--- a/tests/test_roman_image_simulation.py
+++ b/tests/test_roman_image_simulation.py
@@ -79,7 +79,8 @@ def test_simulate_roman_image_with_psf_without_noise():
     kwargs_psf = {
         "point_source_supersampling_factor": 3,
         "psf_type": "PIXEL",
-        "kernel_point_source": psf[0].data / np.sum(psf[0].data),
+        "kernel_point_source": psf[0].data,
+        'kernel_point_source_normalisation': False
     }
     kwargs_numerics = {
         "point_source_supersampling_factor": 3,


### PR DESCRIPTION
The PSFs generated by webbpsf are intentionally not normalized to 1, so this PR removes the automatic normalization that occurs in roman_image_simulation. (this was discussed a while ago but I needed to wait for a bug fix in lenstronomy 1.12.1 in order to modify the test function)