### PR TITLE
Central source check

### DIFF
--- a/slsim/LsstSciencePipeline/lsst_science_pipeline.py
+++ b/slsim/LsstSciencePipeline/lsst_science_pipeline.py
@@ -12,7 +12,6 @@ from slsim.image_simulation import point_source_coordinate_properties
 from slsim.Util.param_util import (
     random_ra_dec,
     fits_append_table,
-    transformmatrix_to_pixelscale,
     detect_object,
 )
 import h5py

--- a/slsim/LsstSciencePipeline/lsst_science_pipeline.py
+++ b/slsim/LsstSciencePipeline/lsst_science_pipeline.py
@@ -181,19 +181,19 @@ def lens_inejection(
     )
     return t
 
+
 def get_dp0_images(butler, ra, dec, band_list, coadd_injection):
     """Retrieve coadd or visit images for the given bands.
-    
+
     :param butler: butler object
     :param ra: ra for the cutout
     :param dec: dec for the cutout
     :param band_list: List of imaging band in which lens need to be
         injected.
-    :param coadd_injection: Boolean. If True, queries the DP0
-        coadd image and if False, queries the single visit DP0
-        images.
-    :return: coadd or single visit image, number of images in coadd, magnitude zero 
-     point, and variance map in specified bands.
+    :param coadd_injection: Boolean. If True, queries the DP0 coadd
+        image and if False, queries the single visit DP0 images.
+    :return: coadd or single visit image, number of images in coadd,
+        magnitude zero point, and variance map in specified bands.
     """
     skymap = butler.get("skyMap")
     point = geom.SpherePoint(ra, dec, geom.degrees)
@@ -204,11 +204,11 @@ def get_dp0_images(butler, ra, dec, band_list, coadd_injection):
     my_tract = tractInfo.tract_id
     my_patch = patchInfo.getSequentialIndex()
     coadd, coadd_nImage, mag_zero_visit, variance_map = [], [], [], []
-    
+
     for band in band_list:
         coaddId = {"tract": my_tract, "patch": my_patch, "band": band}
         coadd_image = butler.get("deepCoadd", dataId=coaddId)
-        
+
         if not coadd_injection:
             visit_info = coadd_image.getInfo().getCoaddInputs().ccds
             index = np.random.randint(0, len(visit_info))
@@ -222,17 +222,19 @@ def get_dp0_images(butler, ra, dec, band_list, coadd_injection):
             coadd.append(visit_image)
             variance_map.append(visit_image.getVariance())
             mag_zero_visit.append(
-            2.5 * np.log10(visit_image.getPhotoCalib().getInstFluxAtZeroMagnitude()))
+                2.5 * np.log10(visit_image.getPhotoCalib().getInstFluxAtZeroMagnitude())
+            )
         else:
             coadd.append(coadd_image)
             variance_map.append(coadd_image.getVariance())
             coadd_nImage.append(butler.get("deepCoadd_nImage", dataId=coaddId))
-    
+
     return coadd, coadd_nImage, mag_zero_visit, variance_map
+
 
 def generate_cutout_bbox(x_center, y_center, num_pix):
     """Generate bounding box for cutout selection.
-    
+
     :param x_center: x value of center of the cutout box in pixel unit
     :param y_center: y value of center of the cutout box in pixel unit
     :param num_pix: number of pixel for the cutout
@@ -242,9 +244,11 @@ def generate_cutout_bbox(x_center, y_center, num_pix):
     xbox_max = x_center + ((num_pix - 1) / 2)
     ybox_min = y_center - ((num_pix - 1) / 2)
     ybox_max = y_center + ((num_pix - 1) / 2)
-    
-    return geom.Box2I(geom.Point2I(xbox_min, ybox_min),
-                      geom.Point2I(xbox_max, ybox_max))
+
+    return geom.Box2I(
+        geom.Point2I(xbox_min, ybox_min), geom.Point2I(xbox_max, ybox_max)
+    )
+
 
 def lens_inejection_fast(
     lens_pop,
@@ -261,7 +265,7 @@ def lens_inejection_fast(
     coadd_year=5,
     band_list=["r", "g", "i"],
     center_box_size=3,
-    center_source_snr_threshold=5
+    center_source_snr_threshold=5,
 ):
     """Chooses a random lens from the lens population and injects it to a DC2
     cutout image. For this one needs to provide a butler to this function. To
@@ -289,9 +293,10 @@ def lens_inejection_fast(
         desired year of coadd.
     :param band_list: List of imaging band in which lens need to be
         injected.
-    :param center_box_size: Size of the central box in arcsec (default is 3 arcsec).
-    :param center_source_snr_threshold: SNR threshold for object detection in center box
-     (default is 5).
+    :param center_box_size: Size of the central box in arcsec (default
+        is 3 arcsec).
+    :param center_source_snr_threshold: SNR threshold for object
+        detection in center box (default is 5).
     :returns: An astropy table containing Injected lens in r-band, DC2
         cutout image in r-band, cutout image with injected lens in r, g
         , and i band
@@ -305,7 +310,12 @@ def lens_inejection_fast(
 
     rgb_band_list = band_list
     coadd, coadd_nImage, mag_zero_visit, variance_map = get_dp0_images(
-        butler=butler, ra=ra, dec=dec, band_list=rgb_band_list, coadd_injection=coadd_injection)
+        butler=butler,
+        ra=ra,
+        dec=dec,
+        band_list=rgb_band_list,
+        coadd_injection=coadd_injection,
+    )
     bbox = coadd[0].getBBox()
     xmin, ymin = bbox.getBegin()
     xmax, ymax = bbox.getEnd()
@@ -313,27 +323,37 @@ def lens_inejection_fast(
 
     valid_cutouts = 0
     table = []
-    #for i in range(len(x_center)):
+    # for i in range(len(x_center)):
     while valid_cutouts < num_cutout_per_patch:
         # Randomly select a position for the cutout
         x_center = np.random.randint(xmin + 150, xmax - 150)
         y_center = np.random.randint(ymin + 150, ymax - 150)
-        cutout_bbox = generate_cutout_bbox(x_center=x_center, 
-                                           y_center=y_center, num_pix=num_pix)
+        cutout_bbox = generate_cutout_bbox(
+            x_center=x_center, y_center=y_center, num_pix=num_pix
+        )
         if isinstance(lens_pop, list):
             lens_class = lens_pop[valid_cutouts]
         else:
             lens_class = lens_pop.select_lens_at_random(**kwargs_lens_cut)
-        injected_final_image, box_center, cutout_image_list,\
-              lens_image, lens_id = [], [], [], [], []
+        injected_final_image, box_center, cutout_image_list, lens_image, lens_id = (
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
         is_valid = True
         for j, band in enumerate(band_list):
             cutout_image = coadd[j][cutout_bbox]
             cutout_variance = variance_map[j][cutout_bbox]
             # Check for existing objects in the cutout image
-            if detect_object(cutout_image.image.array, cutout_variance.array, 
-                pixel_scale=pixel_scale, box_size_arcsec=center_box_size,
-                snr_threshold=center_source_snr_threshold):
+            if detect_object(
+                cutout_image.image.array,
+                cutout_variance.array,
+                pixel_scale=pixel_scale,
+                box_size_arcsec=center_box_size,
+                snr_threshold=center_source_snr_threshold,
+            ):
                 is_valid = False
                 break  # Discard this cutout and try again
             if noise is True:
@@ -372,20 +392,21 @@ def lens_inejection_fast(
                 + [f"injected_lens_{band}" for band in band_list]
                 + ["cutout_center"]
             )
-    
+
             # Construct row data dynamically
             data = (
                 [[[lens_id[0]]], [lens_image[0]], [cutout_image_list[0]]]
                 + [[img] for img in injected_final_image]
                 + [[box_center[0]]]
             )
-    
+
             # Create Table instance
             table_1 = Table(data, names=column_names)
             table.append(table_1)
-            valid_cutouts += 1 # Increase count of successful cutouts
+            valid_cutouts += 1  # Increase count of successful cutouts
     lens_catalog = vstack(table)
     return lens_catalog
+
 
 def multiple_lens_injection(
     lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None, flux=None

--- a/slsim/Util/param_util.py
+++ b/slsim/Util/param_util.py
@@ -567,3 +567,36 @@ def degrade_coadd_data(
     )
 
     return degraded_image, degraded_var_map, degraded_exp_map
+
+def detect_object(image, variance, pixel_scale=0.2, box_size_arcsec=3, snr_threshold=5):
+    """
+    Detect whether the central region of the image contains an object based on SNR.
+    
+    :param image: The input image.
+    :param variance: The variance map of the same size as the image.
+    :param pixel_scale: Pixel scale in arcsec/pixel (default is 0.2 arcsec/pixel).
+    :param box_size_arcsec: Size of the central box in arcsec (default is 3 arcsec).
+    :param snr_threshold: SNR threshold for object detection (default is 5).
+    :return: bool. True if the region contains an object (SNR > threshold), False otherwise.
+    """
+    n = image.shape[0]  # Assuming square image
+    box_size_pix = int(box_size_arcsec / pixel_scale)  # Convert arcsec to pixels
+    half_box = box_size_pix // 2
+    
+    # Determine central region indices
+    center = n // 2
+    x_min, x_max = center - half_box, center + half_box + 1
+    y_min, y_max = center - half_box, center + half_box + 1
+    
+    # Extract central region
+    sub_image = image[x_min:x_max, y_min:y_max]
+    sub_variance = variance[x_min:x_max, y_min:y_max]
+    
+    # Compute total flux and noise
+    total_flux = np.sum(sub_image)
+    total_noise = np.sqrt(np.sum(sub_variance))
+    
+    # Compute SNR
+    snr = total_flux / total_noise if total_noise > 0 else 0
+    
+    return snr > snr_threshold

--- a/tests/test_param_util.py
+++ b/tests/test_param_util.py
@@ -394,8 +394,8 @@ def test_detect_object():
     image1 = image + noise
     result1=detect_object(image1, variance_map2)
     result2=detect_object(noise, variance_map2)
-    assert result1==True
-    assert result2==False
+    assert result1
+    assert not result2
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_param_util.py
+++ b/tests/test_param_util.py
@@ -23,6 +23,7 @@ from slsim.Util.param_util import (
     additional_poisson_noise_with_rescaled_coadd,
     additional_bkg_rms_with_rescaled_coadd,
     degrade_coadd_data,
+    detect_object
 )
 from slsim.Sources.SourceVariability.variability import Variability
 from astropy.io import fits
@@ -382,6 +383,19 @@ def test_degrade_coadd_data():
     assert len(result) == 3
     assert np.mean(image) > np.mean(result[0])
 
+def test_detect_object():
+    path = os.path.dirname(__file__)
+
+    image = np.load(os.path.join(path, "TestData/psf_kernels_for_image_1.npy"))+0.5
+    variance_map1=np.abs(np.random.normal(loc=0.1, scale=0.01, size=(57, 57)))
+    variance_map2=np.abs(np.random.normal(loc=0.1, scale=0.01, size=(57, 57)))
+    std_dev_map = np.sqrt(variance_map1)
+    noise = np.random.normal(loc=0, scale=std_dev_map)
+    image1 = image + noise
+    result1=detect_object(image1, variance_map2)
+    result2=detect_object(noise, variance_map2)
+    assert result1==True
+    assert result2==False
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This PR implements a method to check if an image contains a bright source within the central box of a specified dimension. This is used in the LSST Science Pipeline source injection task. It ensures that our injected lens does not overlap with an existing object.