### PR TITLE
theta_E_infinity for composite models speed up

### DIFF
--- a/slsim/Deflectors/DeflectorTypes/epl_sersic.py
+++ b/slsim/Deflectors/DeflectorTypes/epl_sersic.py
@@ -84,12 +84,14 @@ class EPLSersic(DeflectorBase):
         )
         return e1_light, e2_light
 
-    def mass_model_lenstronomy(self, lens_cosmo=None):
+    def mass_model_lenstronomy(self, lens_cosmo=None, spherical=False):
         """Returns lens model instance and parameters in lenstronomy
         conventions.
 
         :param lens_cosmo: lens cosmology model
         :type lens_cosmo: ~lenstronomy.Cosmo.LensCosmo instance
+        :param spherical: if True, makes spherical assumption
+        :type spherical: bool
         :return: lens_mass_model_list, kwargs_lens_mass
         """
         gamma = self.halo_properties
@@ -113,10 +115,19 @@ class EPLSersic(DeflectorBase):
             }
         ]
         if gamma == 2:
-            lens_mass_model_list = ["SIE"]
+            if spherical is True:
+                lens_mass_model_list = ["SIS"]
+            else:
+                lens_mass_model_list = ["SIE"]
             kwargs_lens_mass[0].pop("gamma")
         else:
-            lens_mass_model_list = ["EPL"]
+            if spherical is True:
+                lens_mass_model_list = ["SPP"]
+            else:
+                lens_mass_model_list = ["EPL"]
+        if spherical is False:
+            kwargs_lens_mass[0]["e1"] = e1_mass_lenstronomy
+            kwargs_lens_mass[0]["e2"] = e2_mass_lenstronomy
         return lens_mass_model_list, kwargs_lens_mass
 
     def light_model_lenstronomy(self, band=None):

--- a/slsim/Deflectors/DeflectorTypes/nfw_cluster.py
+++ b/slsim/Deflectors/DeflectorTypes/nfw_cluster.py
@@ -39,12 +39,14 @@ class NFWCluster(DeflectorBase):
         m_halo, c_halo = self.halo_properties
         return vel_disp_nfw(m_halo, c_halo, cosmo, self.redshift)
 
-    def mass_model_lenstronomy(self, lens_cosmo):
+    def mass_model_lenstronomy(self, lens_cosmo, spherical=False):
         """Returns lens model instance and parameters in lenstronomy
         conventions.
 
         :param lens_cosmo: lens cosmology model
         :type lens_cosmo: ~lenstronomy.Cosmo.LensCosmo instance
+        :param spherical: if True, makes spherical assumption
+        :type spherical: bool
         :return: lens_mass_model_list, kwargs_lens_mass
         """
         lens_mass_model_list, kwargs_lens_mass = self._halo_mass_model_lenstronomy(

--- a/slsim/Deflectors/DeflectorTypes/nfw_hernquist.py
+++ b/slsim/Deflectors/DeflectorTypes/nfw_hernquist.py
@@ -28,7 +28,7 @@ class NFWHernquist(DeflectorBase):
         :return: velocity dispersion [km/s]
         """
         if ("vel_disp" in self._deflector_dict) and (
-            self._deflector_dict["vel_disp"] != -1
+            self._deflector_dict["vel_disp"] >= 0
         ):
             return self._deflector_dict["vel_disp"]
 
@@ -54,15 +54,20 @@ class NFWHernquist(DeflectorBase):
             self._deflector_dict["vel_disp"] = vel_disp
             return self._deflector_dict["vel_disp"]
 
-    def mass_model_lenstronomy(self, lens_cosmo):
+    def mass_model_lenstronomy(self, lens_cosmo, spherical=False):
         """Returns lens model instance and parameters in lenstronomy
         conventions.
 
         :param lens_cosmo: lens cosmology model
         :type lens_cosmo: ~lenstronomy.Cosmo.LensCosmo instance
+        :param spherical: if True, makes spherical assumption
+        :type spherical: bool
         :return: lens_mass_model_list, kwargs_lens_mass
         """
-        lens_mass_model_list = ["NFW_ELLIPSE_CSE", "HERNQUIST_ELLIPSE_CSE"]
+        if spherical is True:
+            lens_mass_model_list = ["NFW", "HERNQUIST"]
+        else:
+            lens_mass_model_list = ["NFW_ELLIPSE_CSE", "HERNQUIST_ELLIPSE_CSE"]
         e1_light_lens, e2_light_lens = self.light_ellipticity
         e1_light_lens_lenstronomy, e2_light_lens_lenstronomy = (
             ellipticity_slsim_to_lenstronomy(
@@ -84,20 +89,21 @@ class NFWHernquist(DeflectorBase):
             {
                 "alpha_Rs": alpha_rs,
                 "Rs": rs_halo,
-                "e1": e1_mass_lenstronomy,
-                "e2": e2_mass_lenstronomy,
                 "center_x": self.deflector_center[0],
                 "center_y": self.deflector_center[1],
             },
             {
                 "Rs": rs_light_angle,
                 "sigma0": sigma0,
-                "e1": e1_light_lens_lenstronomy,
-                "e2": e2_light_lens_lenstronomy,
                 "center_x": self.deflector_center[0],
                 "center_y": self.deflector_center[1],
             },
         ]
+        if spherical is False:
+            kwargs_lens_mass[0]["e1"] = e1_mass_lenstronomy
+            kwargs_lens_mass[0]["e2"] = e2_mass_lenstronomy
+            kwargs_lens_mass[1]["e1"] = e1_light_lens_lenstronomy
+            kwargs_lens_mass[1]["e2"] = e2_light_lens_lenstronomy
         return lens_mass_model_list, kwargs_lens_mass
 
     def light_model_lenstronomy(self, band=None):

--- a/slsim/Deflectors/deflector.py
+++ b/slsim/Deflectors/deflector.py
@@ -4,6 +4,11 @@ from slsim.Deflectors.DeflectorTypes.nfw_cluster import NFWCluster
 from lenstronomy.LightModel.light_model import LightModel
 from lenstronomy.Util import data_util
 from slsim.Util import param_util
+import numpy as np
+import lenstronomy.Util.constants as constants
+from lenstronomy.Cosmo.lens_cosmo import LensCosmo
+from lenstronomy.Analysis.lens_profile import LensProfileAnalysis
+from lenstronomy.LensModel.lens_model import LensModel
 
 _SUPPORTED_DEFLECTORS = ["EPL", "NFW_HERNQUIST", "NFW_CLUSTER"]
 
@@ -167,3 +172,37 @@ class Deflector(object):
             flux_lens_light_local, mag_zero_point=_mag_zero_dummy
         )
         return mag_arcsec2
+
+    def theta_e_infinity(self, cosmo):
+        """
+        Einstein radius for a source at infinity (or well passed where galaxies exist
+
+        :param cosmo: astropy.cosmology instance
+        :return:
+        """
+        if self.deflector_type in ["EPL"]:
+            v_sigma = self._deflector.velocity_dispersion(cosmo=cosmo)
+            theta_E_infinity = (
+                    4 * np.pi * (v_sigma * 1000.0 / constants.c) ** 2 / constants.arcsec
+            )
+        else:
+            _z_source_infty = 100
+            lens_cosmo = LensCosmo(cosmo=cosmo, z_lens=self.redshift, z_source=_z_source_infty)
+            lens_mass_model_list, kwargs_lens_mass = self._deflector.mass_model_lenstronomy(lens_cosmo=lens_cosmo,
+                                                                                            spherical=True)
+            lens_model = LensModel(
+                lens_model_list=lens_mass_model_list,
+                z_lens=self.redshift,
+                z_source_convention=_z_source_infty,
+                multi_plane=False,
+                z_source=_z_source_infty,
+                cosmo=cosmo
+            )
+
+            lens_analysis = LensProfileAnalysis(lens_model=lens_model)
+
+            theta_E_infinity = lens_analysis.effective_einstein_radius(
+                kwargs_lens_mass, r_min=1e-4, r_max=5e1, num_points=100
+            )
+            theta_E_infinity = np.nan_to_num(theta_E_infinity, nan=0)
+        return theta_E_infinity

--- a/slsim/FalsePositives/false_positive_pop.py
+++ b/slsim/FalsePositives/false_positive_pop.py
@@ -103,8 +103,8 @@ class FalsePositivePop(object):
                     continue  # Retry if sources are invalid
 
                 # Step 3: Create false positive
-                vd = deflector.velocity_dispersion(cosmo=self.cosmo)
-                test_area = self._test_area_factor * draw_test_area(v_sigma=vd)
+                theta_e_infinity = deflector.theta_e_infinity(cosmo=self.cosmo)
+                test_area = self._test_area_factor * draw_test_area(theta_e_infinity=theta_e_infinity)
                 false_positive = FalsePositive(
                     deflector_class=deflector,
                     source_class=source,

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -166,6 +166,7 @@ class Lens(LensedSystemBase):
             z_source_convention=self.max_redshift_source_class.redshift,
             multi_plane=False,
             z_source=source.redshift,
+            cosmo=self.cosmo
         )
         lens_eq_solver = LensEquationSolver(lens_model_class)
         source_pos_x, source_pos_y = source.extended_source_position(
@@ -221,6 +222,7 @@ class Lens(LensedSystemBase):
             z_source_convention=self.max_redshift_source_class.redshift,
             multi_plane=False,
             z_source=source.redshift,
+            cosmo=self.cosmo
         )
         lens_eq_solver = LensEquationSolver(lens_model_class)
         point_source_pos_x, point_source_pos_y = source.point_source_position(
@@ -485,6 +487,7 @@ class Lens(LensedSystemBase):
             z_source_convention=self.max_redshift_source_class.redshift,
             multi_plane=False,
             z_source=source.redshift,
+            cosmo=self.cosmo,
         )
         if self.deflector.deflector_type in ["EPL"]:
             kappa_ext_convention = self.los_class.convergence
@@ -506,14 +509,14 @@ class Lens(LensedSystemBase):
         else:
             # numerical solution for the Einstein radius
             lens_analysis = LensProfileAnalysis(lens_model=lens_model)
-            kwargs_lens_ = copy.deepcopy(kwargs_lens)
-            for kwargs in kwargs_lens_:
-                if "center_x" in kwargs:
-                    kwargs["center_x"] = 0
-                if "center_y" in kwargs:
-                    kwargs["center_y"] = 0
+            #kwargs_lens_ = copy.deepcopy(kwargs_lens)
+            #for kwargs in kwargs_lens_:
+            #    if "center_x" in kwargs:
+            #        kwargs["center_x"] = 0
+            #    if "center_y" in kwargs:
+            #        kwargs["center_y"] = 0
             theta_E = lens_analysis.effective_einstein_radius(
-                kwargs_lens_, r_min=1e-4, r_max=5e1, num_points=100
+                kwargs_lens, r_min=1e-4, r_max=5e1, num_points=100
             )
         return theta_E
 
@@ -1174,22 +1177,3 @@ def image_separation_from_positions(image_positions):
         )
         image_separation = np.max(separations)
     return image_separation
-
-
-def theta_e_when_source_infinity(deflector_dict=None, v_sigma=None):
-    """Calculate Einstein radius in arc-seconds for a source at infinity.
-
-    :param deflector_dict: deflector properties
-    :param v_sigma: velocity dispersion in km/s
-    :return: Einstein radius in arc-seconds
-    """
-    if v_sigma is None:
-        if deflector_dict is None:
-            raise ValueError("Either deflector_dict or v_sigma must be provided")
-        else:
-            v_sigma = deflector_dict["vel_disp"]
-
-    theta_E_infinity = (
-        4 * np.pi * (v_sigma * 1000.0 / constants.c) ** 2 / constants.arcsec
-    )
-    return theta_E_infinity

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -3,7 +3,6 @@ import numpy as np
 from slsim.lens import Lens
 from typing import Optional
 from astropy.cosmology import Cosmology
-from slsim.lens import theta_e_when_source_infinity
 from slsim.Sources.source_pop_base import SourcePopBase
 from slsim.LOS.los_pop import LOSPop
 from slsim.Deflectors.deflectors_base import DeflectorsBase
@@ -72,8 +71,8 @@ class LensPop(LensedPopulationBase):
                 source_redshift=_source.redshift, deflector_redshift=_deflector.redshift
             )
             if test_area is None:
-                vel_disp = _deflector.velocity_dispersion(cosmo=self.cosmo)
-                test_area = draw_test_area(v_sigma=vel_disp)
+                theta_e_infinity = _deflector.theta_e_infinity(cosmo=self.cosmo)
+                test_area = draw_test_area(theta_e_infinity=theta_e_infinity)
             else:
                 test_area = test_area
             gg_lens = Lens(
@@ -137,7 +136,7 @@ class LensPop(LensedPopulationBase):
         # TODO: need to implement a version of it. (improve the
         algorithm)
 
-        :param kwargs_lens_cut: validity test keywords. dictionary of
+        :param kwargs_lens_cuts: validity test keywords. dictionary of
             cuts that one wants to apply to the lens. eg:
             kwargs_lens_cut = {}"min_image_separation": 0.5,
             "max_image_separation": 10, "mag_arc_limit": {"i", 24},
@@ -173,8 +172,8 @@ class LensPop(LensedPopulationBase):
         # Draw a population of galaxy-galaxy lenses within the area.
         for _ in range(int(num_lenses / speed_factor)):
             _deflector = self._lens_galaxies.draw_deflector()
-            vel_disp = _deflector.velocity_dispersion(cosmo=self.cosmo)
-            test_area = draw_test_area(v_sigma=vel_disp)
+            theta_e_infinity = _deflector.theta_e_infinity(cosmo=self.cosmo)
+            test_area = draw_test_area(theta_e_infinity=theta_e_infinity)
             num_sources_tested = self.get_num_sources_tested(
                 testarea=test_area * speed_factor
             )
@@ -224,13 +223,11 @@ class LensPop(LensedPopulationBase):
         return lens_population
 
 
-def draw_test_area(**kwargs):
+def draw_test_area(theta_e_infinity):
     """Draw a test area around the deflector.
 
-    :param kwargs: Either deflector dictionary or v_sigma for velocity
-        dispersion.
+    :param theta_e_infinity: Einstein radius for infinitly far away source (Dds/Ds = 1)
     :return: test area in arcsec^2
     """
-    theta_e_infinity = theta_e_when_source_infinity(**kwargs)
     test_area = np.pi * (theta_e_infinity * 2.5) ** 2
     return test_area

--- a/tests/test_Deflectors/test_deflector.py
+++ b/tests/test_Deflectors/test_deflector.py
@@ -103,3 +103,7 @@ class TestDeflector(object):
         npt.assert_almost_equal(
             mag_arcsec2_center / mag_arcsec2_r_eff, 0.9079, decimal=3
         )
+
+    def test_theta_e_when_source_infinity(self):
+        theta_E_infinity = self.deflector.theta_e_infinity(cosmo=None)
+        assert theta_E_infinity < 15

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -8,7 +8,6 @@ from astropy.table import Table
 from slsim.lens import (
     Lens,
     image_separation_from_positions,
-    theta_e_when_source_infinity,
 )
 from slsim.LOS.los_individual import LOSIndividual
 from slsim.LOS.los_pop import LOSPop
@@ -176,17 +175,8 @@ class TestLens(object):
     def test_image_separation_from_positions(self):
         image_positions = self.gg_lens.extended_source_image_positions()[0]
         image_separation = image_separation_from_positions(image_positions)
-        theta_E_infinity = theta_e_when_source_infinity(
-            deflector_dict=self.deflector_dict
-        )
+        theta_E_infinity = self.gg_lens.deflector.theta_e_infinity(cosmo=self.gg_lens.cosmo)
         assert image_separation < 2 * theta_E_infinity
-
-    def test_theta_e_when_source_infinity(self):
-        theta_E_infinity = theta_e_when_source_infinity(
-            deflector_dict=self.deflector_dict
-        )
-        # We expect that theta_E_infinity should be less than 15
-        assert theta_E_infinity < 15
 
     def test_extended_source_magnification(self):
         host_mag = self.gg_lens.extended_source_magnification()[0]

--- a/tests/test_lens_pop.py
+++ b/tests/test_lens_pop.py
@@ -415,7 +415,7 @@ def test_num_lenses_and_sources(gg_lens_pop_instance):
 def test_num_sources_tested_and_test_area(gg_lens_pop_instance):
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
     lens = gg_lens_pop_instance._lens_galaxies.draw_deflector()
-    test_area = draw_test_area(v_sigma=lens.velocity_dispersion(cosmo=cosmo))
+    test_area = draw_test_area(theta_e_infinity=lens.theta_e_infinity(cosmo=cosmo))
     assert (
         0.01 < test_area < 100 * np.pi
     ), "Expected test_area to be between 0.1 and 100*pi,"


### PR DESCRIPTION
simplified Einstein radius estimate at infinity with spherical approximation of the deflector models. Avoids to calculate velocity dispersion for monte carlo drawings of composite models