### PR TITLE
Small update to help microlensing

### DIFF
--- a/slsim/Util/astro_util.py
+++ b/slsim/Util/astro_util.py
@@ -398,7 +398,7 @@ def calculate_accretion_disk_emission(
     rest_frame_wavelength_in_nanometers,
     black_hole_mass_exponent,
     black_hole_spin,
-    eddington_ratio,    
+    eddington_ratio,
     return_spectral_radiance_distribution=False,
 ):
     """This calculates the emission of the accretion disk due to black body
@@ -446,7 +446,7 @@ def calculate_accretion_disk_emission(
 
     if return_spectral_radiance_distribution:
         return emission_map
-        
+
     return np.nansum(emission_map)
 
 

--- a/tests/test_astro_util.py
+++ b/tests/test_astro_util.py
@@ -301,7 +301,7 @@ def test_calculate_accretion_disk_emission():
         black_hole_mass_exponent,
         black_hole_spin,
         eddington_ratio,
-        return_spectral_radiance_distribution=True
+        return_spectral_radiance_distribution=True,
     )
 
     # assert that higher eddington ratio = more emission

--- a/tests/test_astro_util.py
+++ b/tests/test_astro_util.py
@@ -293,11 +293,24 @@ def test_calculate_accretion_disk_emission():
         black_hole_spin,
         eddington_ratio,
     )
+    emission_distribution_3 = calculate_accretion_disk_emission(
+        r_out * 2,
+        r_resolution * 2,
+        inclination_angle,
+        rest_frame_wavelength_in_nm,
+        black_hole_mass_exponent,
+        black_hole_spin,
+        eddington_ratio,
+        return_spectral_radiance_distribution=True
+    )
 
     # assert that higher eddington ratio = more emission
     assert emission_2 > emission_1
     # assert that larger accretion disk = more emission
     assert emission_3 > emission_1
+    # assert the distribution is a np array with total sum equal to emission_3
+    assert isinstance(emission_distribution_3, np.ndarray)
+    assert np.nansum(emission_distribution_3) == emission_3
 
 
 def test_calculate_accretion_disk_response_function():


### PR DESCRIPTION
Microlensing needs the accretion disk's flux distribution. I added 2 lines of code (with updated documentation and associated test function) to address this. The new boolean flag "return_spectral_radiance_distribution" may be set to True in order to get the flux distribution of the accretion disk while using the previously tested code.