### PR TITLE
Einstein radius estimate with spherical model for speed up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 skypy
-lenstronomy>=1.12.2
+lenstronomy>=1.12.6
 astropy>=5.2
 numpy
 #scipy<=1.13.1

--- a/slsim/Deflectors/deflector.py
+++ b/slsim/Deflectors/deflector.py
@@ -207,7 +207,7 @@ class Deflector(object):
             lens_analysis = LensProfileAnalysis(lens_model=lens_model)
 
             theta_E_infinity = lens_analysis.effective_einstein_radius(
-                kwargs_lens_mass, r_min=1e-4, r_max=5e1, num_points=100
+                kwargs_lens_mass, r_min=1e-3, r_max=5e1, num_points=40, spherical_model=True,
             )
             theta_E_infinity = np.nan_to_num(theta_E_infinity, nan=0)
         return theta_E_infinity

--- a/slsim/Deflectors/deflector.py
+++ b/slsim/Deflectors/deflector.py
@@ -207,7 +207,11 @@ class Deflector(object):
             lens_analysis = LensProfileAnalysis(lens_model=lens_model)
 
             theta_E_infinity = lens_analysis.effective_einstein_radius(
-                kwargs_lens_mass, r_min=1e-3, r_max=5e1, num_points=40, spherical_model=True,
+                kwargs_lens_mass,
+                r_min=1e-3,
+                r_max=5e1,
+                num_points=40,
+                spherical_model=True,
             )
             theta_E_infinity = np.nan_to_num(theta_E_infinity, nan=0)
         return theta_E_infinity


### PR DESCRIPTION
I added a feature in lenstronomy when providing a spherical model, the numerical estimate of the Einstein radius requires fewer evaluations of the convergence, and made this accessible through this PR. Requires the latest pip version of lenstronomy 1.12.6