### PR TITLE
Fixed a small typo in deflector.py

### DIFF
--- a/slsim/Deflectors/deflector.py
+++ b/slsim/Deflectors/deflector.py
@@ -135,7 +135,7 @@ class Deflector(object):
     def angular_size_light(self):
         """Angular size of the light component.
 
-        :return: angular size [radian]
+        :return: angular size [arcsec]
         """
         return self._deflector.angular_size_light
 


### PR DESCRIPTION
In the DeflectorTypes Base class, the units are in arcsec, so these should be maintained!