### PR TITLE
Make second_brightest_image cuts on multiple bands

### DIFF
--- a/slsim/Util/astro_util.py
+++ b/slsim/Util/astro_util.py
@@ -962,8 +962,8 @@ def downsample_passband(
     min_wavelength = np.min(passband[0][:])
     max_wavelength = np.max(passband[0][:])
     filter_total_wavelength_coverage = max_wavelength - min_wavelength
-    nbins = int(
-        round(1 + filter_total_wavelength_coverage / output_delta_wavelength, 0)
+    nbins = max(
+        int(round(1 + filter_total_wavelength_coverage / output_delta_wavelength, 0)), 2
     )
     bin_edges = np.linspace(min_wavelength, max_wavelength, nbins)
     # Make throughput

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -254,8 +254,8 @@ class Lens(LensedSystemBase):
             magnitude of the second brightest image and corresponding
             band. If provided, selects lenses where the second brightest
             image has a magnitude less than or equal to provided
-            magnitude. eg: second_bright_image_cut = {"band": "i",
-            "second_bright_mag_max": 23}
+            magnitude. eg: second_bright_image_cut = {"band": ["i"],
+            "mag_max":[23]}
         :return: A boolean or dict of boolean.
         """
         validity_results = {}
@@ -293,8 +293,8 @@ class Lens(LensedSystemBase):
             magnitude of the second brightest image and corresponding
             band. If provided, selects lenses where the second brightest
             image has a magnitude less than or equal to provided
-            magnitude. eg: second_bright_image_cut = {"band": "i",
-            "mag_max": 23}
+            magnitude. eg: second_bright_image_cut = {"band": ["i"],
+            "mag_max":[23]}
         :param source_index: index of a source in source list.
         :return: boolean
         """
@@ -371,7 +371,11 @@ class Lens(LensedSystemBase):
         # the magnitude less or equal to "second_bright_mag_max" provided in the dict
         # second_bright_image_cut.
         if second_brightest_image_cut is not None:
-            for band_max, mag_max in second_brightest_image_cut.items():
+            cut_values = list(second_brightest_image_cut.values())
+            bands = cut_values[0]
+            values = cut_values[1]
+            image_cut_dict = dict(zip(bands, values))
+            for band_max, mag_max in image_cut_dict.items():
                 if self._source_type == "extended":
                     image_magnitude_list = (
                         self.extended_source_magnitude_for_each_image(

--- a/slsim/lens.py
+++ b/slsim/lens.py
@@ -254,8 +254,8 @@ class Lens(LensedSystemBase):
             magnitude of the second brightest image and corresponding
             band. If provided, selects lenses where the second brightest
             image has a magnitude less than or equal to provided
-            magnitude. eg: second_bright_image_cut = {"band": ["i"],
-            "mag_max":[23]}
+            magnitude. e.g.: second_brightest_image_cut = {"i": 23, "g":
+            24, "r": 22}
         :return: A boolean or dict of boolean.
         """
         validity_results = {}
@@ -293,8 +293,8 @@ class Lens(LensedSystemBase):
             magnitude of the second brightest image and corresponding
             band. If provided, selects lenses where the second brightest
             image has a magnitude less than or equal to provided
-            magnitude. eg: second_bright_image_cut = {"band": ["i"],
-            "mag_max":[23]}
+            magnitude.
+            eg: second_brightest_image_cut = {"i": 23, "g": 24, "r": 22}
         :param source_index: index of a source in source list.
         :return: boolean
         """
@@ -370,12 +370,9 @@ class Lens(LensedSystemBase):
         # computes the magnitude of each image and if the second brightest image has
         # the magnitude less or equal to "second_bright_mag_max" provided in the dict
         # second_bright_image_cut.
+
         if second_brightest_image_cut is not None:
-            cut_values = list(second_brightest_image_cut.values())
-            bands = cut_values[0]
-            values = cut_values[1]
-            image_cut_dict = dict(zip(bands, values))
-            for band_max, mag_max in image_cut_dict.items():
+            for band_max, mag_max in second_brightest_image_cut.items():
                 if self._source_type == "extended":
                     image_magnitude_list = (
                         self.extended_source_magnitude_for_each_image(

--- a/slsim/lens_pop.py
+++ b/slsim/lens_pop.py
@@ -140,8 +140,8 @@ class LensPop(LensedPopulationBase):
             cuts that one wants to apply to the lens. eg:
             kwargs_lens_cut = {}"min_image_separation": 0.5,
             "max_image_separation": 10, "mag_arc_limit": {"i", 24},
-            "second_brightest_image_cut": {"i", 24}}. all these cuts are
-            optional.
+            "second_bright_image_cut = {"band": ["i"], "mag_max":[23]}.
+            all these cuts are optional.
         :type kwargs_lens_cuts: dict
         :param multi_source: A boolean value. If True, considers multi
             source lensing. If False, considers single source lensing.
@@ -150,8 +150,8 @@ class LensPop(LensedPopulationBase):
             magnitude of the second brightest image and corresponding
             band. If provided, selects lenses where the second brightest
             image has a magnitude less than or equal to provided
-            magnitude. eg: second_bright_image_cut = {"band": "i",
-            "second_bright_mag_max": 23}
+            magnitude. eg: second_bright_image_cut = {"band": ["i"],
+            "mag_max":[23]}
         :param speed_factor: factor by which the number of deflectors is
             decreased to speed up the calculations.
         :return: List of Lens instances with parameters of the


### PR DESCRIPTION
This is a small enhancement that allows the user to filter out lensed point sources using limiting magnitudes on multiple bands.