### PR TITLE
remove print statement from debugging

### DIFF
--- a/slsim/Sources/SourceTypes/catalog_source.py
+++ b/slsim/Sources/SourceTypes/catalog_source.py
@@ -29,8 +29,6 @@ class CatalogSource(SourceBase):
         :type catalog_path: string
         """
         ang_dist = cosmo.angular_diameter_distance(source_dict["z"])
-        print(ang_dist.value)
-        print(source_dict["angular_size"])
         source_dict["physical_size"] = (
             source_dict["angular_size"] * 4.84814e-6 * ang_dist.value * 1000
         )  # kPc


### PR DESCRIPTION
I accidentally left in some print statements from debugging in the previous PR (of course I only notice it immediately after the PR got merged)