### PR TITLE
edit some docstrings and added features to CatalogSource

### DIFF
--- a/slsim/Sources/SourceTypes/catalog_source.py
+++ b/slsim/Sources/SourceTypes/catalog_source.py
@@ -46,9 +46,9 @@ class CatalogSource(SourceBase):
         :type catalog_path: string
         :param max_scale: The matched COSMOS image will be scaled to have the desired angular size. Scaling up
          results in a more pixelated image. This input determines what the maximum up-scale factor is.
+        :type max_scale: int or float
         :param sersic_fallback: If the matching process returns no matches, then fall back on a single sersic profile.
         :type sersic_fallback: bool
-        :type max_scale: int or float
         """
         super().__init__(extended_source=True, point_source=False, **source_dict)
         self.name = "GAL"
@@ -86,7 +86,7 @@ class CatalogSource(SourceBase):
         """
         if not hasattr(self, "_image"):
             if self.catalog_type == "COSMOS":
-                self._image, self._scale, self._phi, self.ident = (
+                self._image, self._scale, self._phi, self.galaxy_ID = (
                     catalog_util.match_cosmos_source(
                         angular_size=self.angular_size,
                         physical_size=self.physical_size(cosmo=self._cosmo),

--- a/slsim/Sources/SourceTypes/single_sersic.py
+++ b/slsim/Sources/SourceTypes/single_sersic.py
@@ -17,7 +17,7 @@ class SingleSersic(SourceBase):
         :type source_dict: dict or astropy.table.Table
         """
         super().__init__(
-            model_type="DoubleSersic",
+            model_type="SingleSersic",
             extended_source=True,
             point_source=False,
             **source_dict

--- a/slsim/Sources/source.py
+++ b/slsim/Sources/source.py
@@ -19,9 +19,12 @@ class Source(object):
         **source_dict,
     ):
         """
-        :param source_type: Keyword to specify type of the source. Supported source types are
-         'extended', 'point_source', and 'point_plus_extended' supported
-        :type source_type: str
+        :param extended_source_type: Keyword to specify type of the extended source. Supported
+         extended source types are 'single_sersic', 'double_sersic', 'catalog_source', and 'interpolated'.
+        :type extended_source_type: str
+        :param point_source_type: Keyword to specify type of point source. Supported point
+         source types are 'supernova', 'quasar', and 'general_lightcurve'.
+        :type point_source_type: str
         :param source_dict: Source properties. Can be a dictionary or an Astropy table.
          For a detailed description of this dictionary, please see the documentation for
          the individual classes, such as SingleSersic, DoubleSersic, Interpolated classes, SupernovaEvent,
@@ -41,7 +44,7 @@ class Source(object):
             self.source_type = "point_source"
         else:
             raise ValueError(
-                "either extended_source_type of point_source_type need to set."
+                "either extended_source_type or point_source_type needs to be set."
             )
 
         # point sources

--- a/tests/test_Sources/test_SourceTypes/test_catalog_source.py
+++ b/tests/test_Sources/test_SourceTypes/test_catalog_source.py
@@ -9,6 +9,7 @@ import astropy.units as u
 
 from slsim.Pipelines import SkyPyPipeline
 from slsim.Sources.SourcePopulation.galaxies import Galaxies
+from slsim.Sources.SourceTypes.single_sersic import SingleSersic
 from slsim.Sources.SourceTypes.catalog_source import CatalogSource
 from slsim.Sources.source import Source
 from slsim.Deflectors.deflector import Deflector
@@ -102,6 +103,31 @@ class TestCatalogSource:
             source.kwargs_extended_light,
         )
 
+    def test_sersic_fallback(self):
+        cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        source_dict = {
+            "z": 0.5,
+            "mag_i": 20.3,
+            "n_sersic": 0.8,
+            "angular_size": 1.3,  # arcseconds
+            "e1": 0.09697001616620306,
+            "e2": 0.040998265256000574,
+            "center_x": 0.0,
+            "center_y": 0.0,
+            "phi_G": 0,
+        }
+
+        source1 = CatalogSource(
+            cosmo=cosmo,
+            catalog_path=catalog_path,
+            catalog_type="COSMOS",
+            max_scale=0.1,
+            sersic_fallback=True,
+            **source_dict
+        )
+        source2 = SingleSersic(**source_dict)
+        assert source1.kwargs_extended_light() == source2.kwargs_extended_light()
+
 
 def test_source():
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
@@ -125,7 +151,6 @@ def test_source():
         cosmo=cosmo,
         catalog_path=catalog_path,
         catalog_type="COSMOS",
-        # extendedsource_kwargs={"catalog_path": catalog_path, "catalog_type": "COSMOS"},
         **source_dict,
     )
     source2 = Source(extended_source_type="single_sersic", cosmo=cosmo, **source_dict)

--- a/tests/test_Sources/test_SourceTypes/test_catalog_source.py
+++ b/tests/test_Sources/test_SourceTypes/test_catalog_source.py
@@ -123,7 +123,7 @@ class TestCatalogSource:
             catalog_type="COSMOS",
             max_scale=0.1,
             sersic_fallback=True,
-            **source_dict
+            **source_dict,
         )
         source2 = SingleSersic(**source_dict)
         assert source1.kwargs_extended_light() == source2.kwargs_extended_light()


### PR DESCRIPTION
1. During the matching process, the selected COSMOS image is scaled to match the desired angular size. Scaling up can cause the image to become pixelated. The user now has control over what the max up-scale factor is (previously hardcoded to 1).
2. If no matches are found, the user has the option to enable `sersic_fallback`, which defaults to a `SingleSersic` profile.
3. If a match is found, the identification number of the matched image in the COSMOS catalog is now stored so that the user can keep track of whether or not the same galaxy is being selected over and over again in a population.