### PR TITLE
Pass in SkyPy config to SLHammocks pipeline

### DIFF
--- a/data/SkyPy/slhammock_skypy_roman.yml
+++ b/data/SkyPy/slhammock_skypy_roman.yml
@@ -1,0 +1,16 @@
+cosmology: !astropy.cosmology.default_cosmology.get []
+tables:
+  halo:
+      z: PLACEHOLDER_Z
+      stellar_mass: PLACEHOLDER_MASS
+      coeff: !skypy.galaxies.spectrum.dirichlet_coefficients
+        alpha0: [2.461, 2.358, 2.568, 2.268, 2.402]
+        alpha1: [2.410, 2.340, 2.200, 2.540, 2.464]
+        weight: [3.84e+09, 1.57e+06, 3.91e+08, 4.66e+10, 3.03e+07]
+        redshift: $halo.z
+      mag_F062, mag_F087, mag_F106, mag_F129, mag_F158, mag_F184, mag_F146, mag_F213: !skypy.galaxies.spectrum.kcorrect.apparent_magnitudes
+        coefficients: $halo.coeff
+        redshift: $halo.z
+        filters: ['Roman-F062', 'Roman-F087', 'Roman-F106', 'Roman-F129', 'Roman-F158', 'Roman-F184', 'Roman-F146', 'Roman-F213']
+        stellar_mass: $halo.stellar_mass
+        cosmology: $cosmology

--- a/slsim/Pipelines/sl_hammocks_pipeline.py
+++ b/slsim/Pipelines/sl_hammocks_pipeline.py
@@ -24,6 +24,7 @@ class SLHammocksPipeline:
 
     def __init__(
         self,
+        skypy_config=None,
         slhammocks_config=None,
         sky_area=None,
         cosmo=None,
@@ -33,6 +34,8 @@ class SLHammocksPipeline:
         loghm_max=16.0,
     ):
         """
+        :param skypy_config: path to the SkyPy configuration file.
+        :type skypy_config: string or None
         :param slhammocks_config: path to the deflector population csv file for 'halo-model'
                             If None, generate the population. Not supported at this time.
         :type slhammocks_config: string or None
@@ -107,9 +110,13 @@ class SLHammocksPipeline:
             table = table_translator_for_slsim(table, cosmo)
 
             self._pipeline = table
-        skypy_config = os.path.join(module_path, "data/SkyPy/slhammock_skypy.yml")
+
+        # load SkyPy configuration
+        if skypy_config is None:
+            skypy_config = os.path.join(module_path, "data/SkyPy/slhammock_skypy.yml")
         with open(skypy_config, "r") as file:
             content = file.read()
+
         # replace z: PLACEHOLDER_Z with halo redshift
         redshift_array = list(self._pipeline["z"].value)
         old_z = "z: PLACEHOLDER_Z"

--- a/tests/test_Pipelines/test_sl_hammocks_pipeline.py
+++ b/tests/test_Pipelines/test_sl_hammocks_pipeline.py
@@ -27,6 +27,31 @@ class TestSkyPyPipeline(object):
             z_max=5,
         )
 
+    def test_specifying_skypy_configuration(self):
+        # use case: Roman simulation
+
+        import os
+        import speclite
+        from slsim.Pipelines import roman_speclite
+
+        # load Roman speclite filters
+        roman_speclite.configure_roman_filters()
+        roman_filters = roman_speclite.filter_names()
+        speclite.filters.load_filters(*roman_filters)
+
+        skypy_config = os.path.join(
+            os.path.dirname(__file__),
+            "../../data/SkyPy/slhammock_skypy_roman.yml",
+        )
+        pipeline = SLHammocksPipeline(
+            skypy_config=skypy_config,
+            sky_area=self.sky_area,
+            cosmo=self.cosmo,
+            z_min=0.01,
+            z_max=2,
+        )
+        assert pipeline._skypy_pipeline is not None
+
     def test_cosmology_initialization(self):
         sky_area = self.sky_area
         galaxy_cosmo0 = LambdaCDM(H0=70, Om0=0.15, Ob0=0.02, Ode0=0.85, Tcmb0=2.725)


### PR DESCRIPTION
SkyPy config file is necessary for SLHammocks pipeline for stellar masses and photometric magnitudes. Previously, SkyPy config file was hard-coded to one using LSST filters. Now, configurable so end-user can tweak. Example use case is using SLHammocks pipeline with Roman: see unit test `tests/test_Pipelines/test_sl_hammocks_pipeline.py`.