### PR TITLE
Workaround For Fixing SCOTCH Usage Without Refactor

### DIFF
--- a/slsim/Sources/SourcePopulation/scotch_sources.py
+++ b/slsim/Sources/SourcePopulation/scotch_sources.py
@@ -277,6 +277,9 @@ class ScotchSources(SourcePopBase):
     def _build_host_dict(self, host_grp: h5py.Group, host_idx: int) -> dict:
         
         host = {}
+        if host_grp['z'][host_idx] == 999.0:
+            return host
+
         for name, ds in host_grp.items():
             
             if not isinstance(ds, h5py.Dataset):
@@ -327,7 +330,15 @@ class ScotchSources(SourcePopBase):
 
     def draw_source(self):
         """Uniform over classes; within chosen class, uniform over all survivors."""
-        pass
+        
+        transient, host = self._draw_source_dict()
+        if not host:
+            # Point Source for hostless transient
+            pass
+        else:
+            #PointPlusExtendedSource for transient with host
+            pass
+        
 
     def close(self):
         try:

--- a/slsim/Sources/SourcePopulation/scotch_sources.py
+++ b/slsim/Sources/SourcePopulation/scotch_sources.py
@@ -16,13 +16,10 @@ from slsim.Sources.SourcePopulation.source_pop_base import SourcePopBase
 BANDS = ("u", "g", "r", "i", "z", "Y")
 SCOTCH_MAPPINGS = {
     'n0': 'n_sersic_0',
-    'n1': 'n_sersice_1',
+    'n1': 'n_sersic_1',
     'e0': 'ellipticity0',
     'e1': 'ellipticity1',
 }
-
-def _as_str(x):
-    return x.decode("utf-8") if isinstance(x, (bytes, np.bytes_)) else x
 
 def _norm_band_names(bands: list[str]) -> list[str]:
     out = []
@@ -187,12 +184,21 @@ class ScotchSources(SourcePopBase):
                     "the provided kwargs_cut filters and will be ignored.",
                 )
 
-        self.source_number = total
-        self.source_number_selected = total_selected
-        self.transient_types = active_types
+        self.n_source = total
+        self.n_source_selected = total_selected
+        self.active_transient_types = active_types
         
-        if not self.source_number_selected:
+        if self.n_source_selected == 0:
             raise ValueError("No objects satisfy the provided kwargs_cut filters.")
+
+    @property
+    def source_number(self) -> int:
+        return self.n_source
+
+    @property
+    def source_number_selected(self) -> int:
+        return self.n_source_selected    
+
 
     # -------------------- filtering helpers --------------------
 
@@ -322,7 +328,7 @@ class ScotchSources(SourcePopBase):
         return host
 
     def _draw_source_dict(self, *args, **kwargs) -> dict:
-        cls = self.rng.choice(self.active_types)
+        cls = self.rng.choice(self.active_transient_types)
         s, i = self._sample_from_class(cls)
         g = s.grp
 

--- a/slsim/Sources/SourcePopulation/scotch_sources.py
+++ b/slsim/Sources/SourcePopulation/scotch_sources.py
@@ -350,7 +350,7 @@ class ScotchSources(SourcePopBase):
         
         return source_dict, has_host
 
-    def draw_source(self):
+    def draw_source(self, *args, **kwargs) -> Source:
         """Uniform over classes; within chosen class, uniform over all survivors."""
         
         source_dict, has_host = self._draw_source_dict() 

--- a/slsim/Sources/SourcePopulation/scotch_sources.py
+++ b/slsim/Sources/SourcePopulation/scotch_sources.py
@@ -332,12 +332,21 @@ class ScotchSources(SourcePopBase):
         """Uniform over classes; within chosen class, uniform over all survivors."""
         
         transient, host = self._draw_source_dict()
+        source_dict = transient | host
+        
+        point_source_type = "general_lightcurve"
+        extended_source_type = "double_sersic"
         if not host:
-            # Point Source for hostless transient
-            pass
-        else:
-            #PointPlusExtendedSource for transient with host
-            pass
+            extended_source_type = None
+
+        source = Source(
+            cosmo=self._cosmo,
+            extended_source_type=extended_source_type,
+            point_source_type=point_source_type,
+            **source_dict
+        )
+
+        return source
         
 
     def close(self):

--- a/slsim/Sources/SourceTypes/general_lightcurve.py
+++ b/slsim/Sources/SourceTypes/general_lightcurve.py
@@ -33,7 +33,7 @@ class GeneralLightCurve(SourceBase):
             extended_source=False,
             **kwargs
         )
-        self.name = "LC"
+        self.name = kwargs.get("name", "LC")
         # These are the keywords that kwargs dict should contain
         self._MJD = MJD
 

--- a/slsim/Sources/__init__.py
+++ b/slsim/Sources/__init__.py
@@ -1,4 +1,5 @@
 from slsim.Sources.SourcePopulation.galaxies import Galaxies
+from slsim.Sources.SourcePopulation.scotch_sources import ScotchSources
 from slsim.Sources.SourcePopulation.point_sources import PointSources
 from slsim.Sources.SourcePopulation.point_plus_extended_sources import (
     PointPlusExtendedSources,
@@ -11,4 +12,5 @@ __all__ = [
     "PointPlusExtendedSources",
     "QuasarCatalog",
     "SupernovaeCatalog",
+    "ScotchSources",
 ]


### PR DESCRIPTION
This PR Implements a new Source Population called ScotchSources. This work-around is necessary, since the current usage of the SCOTCH catalog simply uses the HostTable from SCOTCH and ignores the connection between host galaxies and transient classes, arguably the main reason for SCOTCH's existence.

This new population draws point source light curves from the SCOTCH TransientTable and the corresponding host galaxy from the SCOTCH HostTable. Dependent on if a given transient is hostless, a draw produces either a PointPlusExtendedSource or PointSource. The point source in both cases is instantiated as a general lightcurve, i.e. linear interpolation is used.

TODOS:

- [ ] Add Redshift Cut-dependent Rates: The rates reported in [Lokken et al 22](https://arxiv.org/abs/2206.02815) are for the full-sky up to z<3. If we use redshift cuts on the sources, we need to recalculate the rates using the volumetric rate for each class
- [ ] Rate-based Transient Class Sampling: Transients are currently sampled uniformly, which will lead to over-representation of rare transients. Need to add weighted class sampling when drawing a source, with weights tied to transient rates.
- [ ] Effective Sky Area: Due to using the catalog directly, different classes are over or undersampled. We can calculate an effective sky-area for the population as A_eff = A_{full_sky} * sum_c N_c^{sim} / sum_c N_c^{full_sky}, where N_c^{sim} and N_c^{full_sky} are the number of simulated and expected transients of class c.
- [ ] Add Unit Tests
- [ ] Add Docstrings