### PR TITLE
Keep num_pix parameter name consistent across slsim

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 skypy
 jaxtronomy
-lenstronomy>=1.13.6
+lenstronomy>=1.14.1
 astropy>=5.2
 numpy
 #scipy<=1.13.1

--- a/slsim/Halos/halos_ray_tracing.py
+++ b/slsim/Halos/halos_ray_tracing.py
@@ -366,7 +366,7 @@ class HalosRayTracing(object):
 
         # Use lenstronomy utility to make grid
         x_grid, y_grid = make_grid(
-            numPix=num_points, deltapix=2 * radius_arcsec / num_points
+            num_pix=num_points, delta_pix=2 * radius_arcsec / num_points
         )
         x_grid, y_grid = x_grid[mask_1D], y_grid[mask_1D]
 

--- a/slsim/Halos/halos_statistics.py
+++ b/slsim/Halos/halos_statistics.py
@@ -486,7 +486,7 @@ class HalosStatistics(HalosLensBase):
 
         # Use lenstronomy utility to make grid
         x_grid, y_grid = make_grid(
-            numPix=num_points, deltapix=2 * (radius_arcsec / 2.0) / num_points
+            num_pix=num_points, delta_pix=2 * (radius_arcsec / 2.0) / num_points
         )
         x_grid, y_grid = x_grid[mask_1D], y_grid[mask_1D]
 

--- a/slsim/ImageSimulation/image_simulation.py
+++ b/slsim/ImageSimulation/image_simulation.py
@@ -116,7 +116,7 @@ def simulate_image(
     if kwargs_psf is not None:
         kwargs_single_band.update(kwargs_psf)
     sim_api = SimAPI(
-        numpix=num_pix, kwargs_single_band=kwargs_single_band, kwargs_model=kwargs_model
+        num_pix=num_pix, kwargs_single_band=kwargs_single_band, kwargs_model=kwargs_model
     )
     kwargs_lens_light, kwargs_source, kwargs_ps = sim_api.magnitude2amplitude(
         kwargs_lens_light_mag=kwargs_params.get("kwargs_lens_light", None),
@@ -184,7 +184,7 @@ def sharp_image(
     }  # these are keywords not being used but need to be set in
     ##SimAPI
     sim_api = SimAPI(
-        numpix=num_pix, kwargs_single_band=kwargs_band, kwargs_model=kwargs_model
+        num_pix=num_pix, kwargs_single_band=kwargs_band, kwargs_model=kwargs_model
     )
     kwargs_lens_light, kwargs_source, kwargs_ps = sim_api.magnitude2amplitude(
         kwargs_lens_light_mag=kwargs_params.get("kwargs_lens_light", None),
@@ -307,7 +307,7 @@ def image_data_class(
         "kwargs_pixel_grid": centered_coordinate_system(num_pix, transform_pix2angle),
     }
     sim_api = SimAPI(
-        numpix=num_pix, kwargs_single_band=kwargs_band, kwargs_model=kwargs_model
+        num_pix=num_pix, kwargs_single_band=kwargs_band, kwargs_model=kwargs_model
     )
 
     imagedata = sim_api.data_class

--- a/slsim/ImageSimulation/image_simulation.py
+++ b/slsim/ImageSimulation/image_simulation.py
@@ -116,7 +116,9 @@ def simulate_image(
     if kwargs_psf is not None:
         kwargs_single_band.update(kwargs_psf)
     sim_api = SimAPI(
-        num_pix=num_pix, kwargs_single_band=kwargs_single_band, kwargs_model=kwargs_model
+        num_pix=num_pix,
+        kwargs_single_band=kwargs_single_band,
+        kwargs_model=kwargs_model,
     )
     kwargs_lens_light, kwargs_source, kwargs_ps = sim_api.magnitude2amplitude(
         kwargs_lens_light_mag=kwargs_params.get("kwargs_lens_light", None),

--- a/slsim/ImageSimulation/roman_image_simulation.py
+++ b/slsim/ImageSimulation/roman_image_simulation.py
@@ -139,7 +139,7 @@ def simulate_roman_image(
     kwargs_single_band["pixel_scale"] /= oversample
 
     sim_api = SimAPI(
-        numpix=num_pix * oversample,
+        num_pix=num_pix * oversample,
         kwargs_single_band=kwargs_single_band,
         kwargs_model=kwargs_model,
     )

--- a/slsim/Lenses/lens.py
+++ b/slsim/Lenses/lens.py
@@ -1307,7 +1307,7 @@ class Lens(LensedSystemBase):
         # TODO: this does not work well for clusters when the lensed source is relatively small compared to the image
         num_pix = 200
         delta_pix = theta_E * 4 / num_pix
-        x, y = util.make_grid(numPix=num_pix, deltapix=delta_pix)
+        x, y = util.make_grid(num_pix=num_pix, delta_pix=delta_pix)
         x += center_source[0]
         y += center_source[1]
         beta_x, beta_y = lens_model_class.ray_shooting(x, y, kwargs_lens)

--- a/tests/test_Lenses/test_lens.py
+++ b/tests/test_Lenses/test_lens.py
@@ -555,7 +555,7 @@ class TestLens(object):
         from lenstronomy.Util.util import make_grid
 
         delta_pix = 0.05
-        x, y = make_grid(numPix=200, deltapix=delta_pix)
+        x, y = make_grid(num_pix=200, delta_pix=delta_pix)
         kappa_star = self.gg_lens.kappa_star(x, y)
         stellar_mass_from_kappa_star = (
             np.sum(kappa_star)


### PR DESCRIPTION
Updated lens.py, image_simulation.py, roman_image_simulation.py, halos_ray_tracing.py, halos_statistics.py, test_lens.py.
To make `num_pix` consistent across slsim.