### PR TITLE
making the point source parameters more accessible and consistent

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,8 @@ import slsim
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "nbsphinx"]
+# Render both the class docstring and __init__'s docstring
+autoclass_content = "both"
 nbsphinx_allow_errors = True
 show_warnings_types = True
 suppress_warnings = ["ref.python"]

--- a/slsim/Sources/SourcePopulation/point_plus_extended_sources.py
+++ b/slsim/Sources/SourcePopulation/point_plus_extended_sources.py
@@ -47,6 +47,13 @@ class PointPlusExtendedSources(Galaxies):
             "i", "r"], "sn_type": "Ia", "sn_absolute_mag_band": "bessellb",
             "sn_absolute_zpsys": "ab", "lightcurve_time": np.linspace(-50, 100, 150),
             "sn_modeldir": None}.
+         Provides population-level default values applied uniformly to every draw.
+         Any key here may be overridden on a per-object basis by including a
+         same-named column in `point_plus_extended_sources_list` -- the catalog
+         value takes precedence. Note this dict, together with the catalog row, is
+         also shared with the extended-source half of the combined source (see
+         `PointPlusExtendedSource` for how each half reads only its own relevant
+         keys and ignores the rest).
         """
         if kwargs_cut is None:
             kwargs_cut = {}
@@ -82,10 +89,12 @@ class PointPlusExtendedSources(Galaxies):
         )
         if kwargs_source is None:
             return None
+        # per-object catalog values override the joint/population-level defaults
+        # on key collision, rather than raising (as a direct double-** unpack would)
+        merged_kwargs = {**self._joint_point_source_kwargs, **kwargs_source}
         source_class = Source(
             cosmo=self._cosmo,
             point_source_type=self._point_source_type,
-            **self._joint_point_source_kwargs,
-            **kwargs_source
+            **merged_kwargs
         )
         return source_class

--- a/slsim/Sources/SourcePopulation/point_plus_extended_sources.py
+++ b/slsim/Sources/SourcePopulation/point_plus_extended_sources.py
@@ -46,8 +46,8 @@ class PointPlusExtendedSources(Galaxies):
          row, is also shared with the extended-source half of the combined source
          (see `PointPlusExtendedSource` for how each half reads only its own
          relevant keys and ignores the rest).
-         For supernova kwargs, please see documentation of SupernovaEvent class.
-         For quasar kwargs, please see documentation of Quasar class.
+         For supernova kwargs, please see documentation of SupernovaEvent class (slsim/Sources/SourceTypes/supernova_event.py).
+         For quasar kwargs, please see documentation of Quasar class (slsim/Sources/SourceTypes/quasar.py).
          Eg of supernova kwargs::
 
              joint_point_source_kwargs = {

--- a/slsim/Sources/SourcePopulation/point_plus_extended_sources.py
+++ b/slsim/Sources/SourcePopulation/point_plus_extended_sources.py
@@ -39,21 +39,26 @@ class PointPlusExtendedSources(Galaxies):
         :param extended_source_type: keyword for number of sersic profile to use in source
          light model. accepted kewords: "single_sersic", "double_sersic".
         :param joint_point_source_kwargs: dictionary of keyword arguments for PointSource that are joint among all
-         point sources.
-         For supernova kwargs dict, please see documentation of SupernovaEvent class.
-         For quasar kwargs dict, please see documentation of Quasar class.
-         Eg of supernova kwargs: point_source_kwargs={
-         "variability_model": "light_curve", "kwargs_variability": ["supernovae_lightcurve",
-            "i", "r"], "sn_type": "Ia", "sn_absolute_mag_band": "bessellb",
-            "sn_absolute_zpsys": "ab", "lightcurve_time": np.linspace(-50, 100, 150),
-            "sn_modeldir": None}.
-         Provides population-level default values applied uniformly to every draw.
-         Any key here may be overridden on a per-object basis by including a
-         same-named column in `point_plus_extended_sources_list` -- the catalog
-         value takes precedence. Note this dict, together with the catalog row, is
-         also shared with the extended-source half of the combined source (see
-         `PointPlusExtendedSource` for how each half reads only its own relevant
-         keys and ignores the rest).
+         point sources. Provides population-level default values applied uniformly
+         to every draw. Any key here may be overridden on a per-object basis by
+         including a same-named column in `point_plus_extended_sources_list` -- the
+         catalog value takes precedence. Note this dict, together with the catalog
+         row, is also shared with the extended-source half of the combined source
+         (see `PointPlusExtendedSource` for how each half reads only its own
+         relevant keys and ignores the rest).
+         For supernova kwargs, please see documentation of SupernovaEvent class.
+         For quasar kwargs, please see documentation of Quasar class.
+         Eg of supernova kwargs::
+
+             joint_point_source_kwargs = {
+                 "variability_model": "light_curve",
+                 "kwargs_variability": ["supernovae_lightcurve", "i", "r"],
+                 "sn_type": "Ia",
+                 "sn_absolute_mag_band": "bessellb",
+                 "sn_absolute_zpsys": "ab",
+                 "lightcurve_time": np.linspace(-50, 100, 150),
+                 "sn_modeldir": None,
+             }
         """
         if kwargs_cut is None:
             kwargs_cut = {}

--- a/slsim/Sources/SourcePopulation/point_sources.py
+++ b/slsim/Sources/SourcePopulation/point_sources.py
@@ -33,7 +33,10 @@ class PointSources(SourcePopBase):
          Supported point source types are "supernova", "quasar", "general_lightcurve".
         :param joint_point_source_kwargs: dictionary of keyword arguments for point sources that are joint. It should
          contain keywords for point_source_type and other keywords associated with
-         point source.
+         point source. Provides population-level default values applied uniformly
+         to every draw. Any key here may be overridden on a per-object basis by
+         including a same-named column in `point_source_list` -- the catalog value
+         takes precedence.
         """
         if joint_point_source_kwargs is None:
             joint_point_source_kwargs = {}
@@ -68,11 +71,13 @@ class PointSources(SourcePopBase):
             z_max=z_max, z_min=z_min, galaxy_index=object_index
         )
 
+        # per-object catalog values override the joint/population-level defaults
+        # on key collision, rather than raising (as a direct double-** unpack would)
+        merged_kwargs = {**self._joint_point_source_kwargs, **point_source}
         source_class = Source(
             cosmo=self._cosmo,
             point_source_type=self._point_source_type,
-            **self._joint_point_source_kwargs,
-            **point_source
+            **merged_kwargs
         )
 
         return source_class

--- a/slsim/Sources/SourceTypes/general_lightcurve.py
+++ b/slsim/Sources/SourceTypes/general_lightcurve.py
@@ -9,6 +9,20 @@ class GeneralLightCurve(SourceBase):
     def __init__(self, MJD, variability_model="light_curve", **kwargs):
         """
 
+        Parameters fall into two categories:
+
+        - **Required per-object catalog data** (passed via ``kwargs``/``source_dict``,
+          typically one row of a catalog Table): at minimum ``z`` (redshift) and at
+          least one ``ps_mag_<band>`` entry matching ``MJD`` in length.
+        - **Population-level config** (the explicit named arguments ``MJD`` and
+          ``variability_model``): normally the same for every draw, but may be
+          overridden on a per-object basis by including a same-named column in the
+          input catalog (see `PointSources`/`PointPlusExtendedSources`).
+
+        Unlike `Quasar`, this class does not set ``allow_more_source_dict=True``, so
+        unrecognized/misspelled keys in ``kwargs`` raise a clear error at
+        construction time (consistent with `Quasar` and `SupernovaEvent` after the
+        AGN-parameter transparency pass).
 
         :param MJD: list of times of the recorded magnitudes, defined in the rest
          (source) frame relative to time_zero_point, consistent with the convention
@@ -27,7 +41,9 @@ class GeneralLightCurve(SourceBase):
          "ps_mag_i": np.array([15, 16, 17, 18, 19, 20, 21, 22, 23]), "ra_off": 0.001,
            "dec_off": 0.002}
         :type source_dict: dict or astropy.table.Table
-        :param kwargs: dictionary of keyword arguments for a source of lightcurve.
+        :param kwargs: required per-object catalog data (dict or one row of an
+         Astropy table). Must contain at least redshift (``z``) and at least one
+         ``ps_mag_<band>`` entry.
 
         """
 

--- a/slsim/Sources/SourceTypes/general_lightcurve.py
+++ b/slsim/Sources/SourceTypes/general_lightcurve.py
@@ -33,17 +33,13 @@ class GeneralLightCurve(SourceBase):
         :param variability_model: keyword for variability model to be used. This is an
             input for the Variability class.
         :type variability_model: str
-        :param source_dict: Source properties. May be a dictionary or an Astropy table.
-         This table or dict should contain atleast redshift of a supernova, offset from
-         the host if host galaxy is available, and lightcurve in a desired band.
-         eg: data={"z": 0.8, "MJD":
-         np.array([1,2,3,4,5,6,7,8,9]),
-         "ps_mag_i": np.array([15, 16, 17, 18, 19, 20, 21, 22, 23]), "ra_off": 0.001,
-           "dec_off": 0.002}
-        :type source_dict: dict or astropy.table.Table
         :param kwargs: required per-object catalog data (dict or one row of an
          Astropy table). Must contain at least redshift (``z``) and at least one
-         ``ps_mag_<band>`` entry.
+         ``ps_mag_<band>`` entry, and may include ``ra_off``/``dec_off`` if a host
+         galaxy is available.
+         eg: {"z": 0.8, "MJD": np.array([1,2,3,4,5,6,7,8,9]),
+         "ps_mag_i": np.array([15, 16, 17, 18, 19, 20, 21, 22, 23]),
+         "ra_off": 0.001, "dec_off": 0.002}
 
         """
 

--- a/slsim/Sources/SourceTypes/point_plus_extended_source.py
+++ b/slsim/Sources/SourceTypes/point_plus_extended_source.py
@@ -14,17 +14,21 @@ class PointPlusExtendedSource(PointSource, ExtendedSource):
         **source_dict,
     ):
         """
-        :param source_dict: Source properties. Can be a dictionary or an Astropy table.
-         For a detailed description of this dictionary, please see the documentation for
-         the SingleSersic, DoubleSersic, Interpolated classes, Supernova, and Quasar class.
-        :type source_dict: dict or astropy.table.Table .
-         eg of a supernova plus host galaxy dict: {"z": 0.8, "mag_i": 22, "n_sersic": 1,
+        :param source_dict: Source properties -- a dict or one row of an Astropy
+         table, containing both host-galaxy and point-source catalog data (each
+         half of this combined source reads only its own relevant keys and ignores
+         the rest). For a detailed description of the required keys, see the
+         documentation for the SingleSersic, DoubleSersic, Interpolated,
+         SupernovaEvent, and Quasar classes. Example of a supernova + host galaxy source_dict:
+         {"z": 0.8, "mag_i": 22, "n_sersic": 1,
            "angular_size": 0.10, "e1": 0.002, "e2": 0.001, "ra_off": 0.001, "dec_off": 0.005}
+        :type source_dict: dict or astropy.table.Table
         :param extended_source_type: keyword for specifying light profile model.
-        :type extended_source_type: str. supported types are "single_sersic",
-         "double_sersic", "interpolated".
+         Supported types are "single_sersic", "double_sersic", "interpolated".
+        :type extended_source_type: str
         :param point_source_type: keyword for specifying point source type.
-        :type point_source_type: str. supported types are "supernova", "quasar", "general_lightcurve".
+         Supported types are "supernova", "quasar", "general_lightcurve".
+        :type point_source_type: str
         """
         # Initialize the extended source. Here, source_dict will contain both host
         # galaxy and point source information but only extended source properties will

--- a/slsim/Sources/SourceTypes/quasar.py
+++ b/slsim/Sources/SourceTypes/quasar.py
@@ -4,7 +4,7 @@ from slsim.Sources.SourceVariability.variability import (
     reprocess_with_lamppost_model,
 )
 from slsim.Sources.SourceVariability import agn
-from slsim.Sources.SourceTypes.source_base import SourceBase, _AGN_VARIABILITY_KEYS
+from slsim.Sources.SourceTypes.source_base import SourceBase
 from slsim.ImageSimulation.image_quality_lenstronomy import (
     get_speclite_filternames,
     get_all_supported_bands,
@@ -27,6 +27,16 @@ class Quasar(SourceBase):
         variability_model="light_curve",
         random_seed=None,
         cosmo=None,
+        black_hole_mass_exponent=None,
+        black_hole_spin=None,
+        inclination_angle=None,
+        r_out=None,
+        r_resolution=None,
+        eddington_ratio=None,
+        accretion_disk=None,
+        corona_height=None,
+        driving_variability_model=None,
+        intrinsic_light_curve=None,
         **kwargs
     ):
         """
@@ -53,9 +63,63 @@ class Quasar(SourceBase):
             a dictionary and this dict should be passed to the Variability class.
         :type kwargs_variability: list of str
         :param kwargs_variability_model: Pre-computed variabilities for each band (default=None)
+
+        AGN accretion-disk parameters (all optional). Any left as ``None`` are drawn
+        randomly by :class:`~slsim.Sources.SourceVariability.agn.RandomAgn` from
+        ``agn_bounds_dict`` (or ``input_agn_bounds_dict`` if provided) the first time
+        the AGN model is needed (on first access of ``.light_curve`` or
+        ``update_microlensing_kwargs_source_morphology``) -- this is a deliberate
+        generative feature (population diversity), not a fallback to guard against.
+        See :mod:`slsim.Sources.SourceVariability.agn` for the sampling distributions.
+
+        :param black_hole_mass_exponent: mass exponent of the SMBH,
+         log10(M_BH/M_sun). If ``None``, drawn from
+         ``agn_bounds_dict["black_hole_mass_exponent_bounds"]``.
+        :type black_hole_mass_exponent: float or None
+        :param black_hole_spin: dimensionless spin of the SMBH, in [-1, 1]. 0 is
+         Schwarzschild; negative values are retrograde relative to the disk. If
+         ``None``, drawn from ``agn_bounds_dict["black_hole_spin_bounds"]``.
+        :type black_hole_spin: float or None
+        :param inclination_angle: inclination of the AGN disk w.r.t. the observer,
+         in degrees. If ``None``, drawn from
+         ``agn_bounds_dict["inclination_angle_bounds"]``.
+        :type inclination_angle: float or None
+        :param r_out: maximum radius of the disk, in gravitational radii. If
+         ``None``, drawn from ``agn_bounds_dict["r_out_bounds"]``.
+        :type r_out: float or None
+        :param eddington_ratio: fraction of the Eddington luminosity the disk is
+         radiating with (accretion-rate proxy; thin-disk solutions are only valid
+         for relatively low values). If ``None``, drawn from
+         ``agn_bounds_dict["eddington_ratio_bounds"]``.
+        :type eddington_ratio: float or None
+        :param accretion_disk: accretion disk model name. Currently only
+         ``"thin_disk"`` is supported. If ``None``, chosen randomly from
+         ``agn_bounds_dict["supported_disk_models"]`` (currently only one option).
+        :type accretion_disk: str or None
+        :param r_resolution: number of radial pixels the disk is resolved to.
+         Unlike the five parameters above, this is *not* part of `RandomAgn`'s
+         random-fill set -- if left ``None``, a default is applied deeper inside
+         the lamppost reprocessing model (see
+         :mod:`slsim.Sources.SourceVariability.variability`).
+        :type r_resolution: int or None
+        :param corona_height: height of the X-ray corona above the disk, used in
+         the lamppost reprocessing model. Same not-randomly-filled caveat as
+         ``r_resolution``.
+        :type corona_height: float or None
+        :param driving_variability_model: reserved/rarely-used passthrough key
+         consumed only by the lamppost reprocessing model directly; do not confuse
+         with ``agn_driving_variability_model`` above, which is the parameter
+         actually used to select the driving-signal model for `RandomAgn`/`Agn`.
+         Leave as ``None`` unless you specifically know you need it.
+        :type driving_variability_model: str or None
+        :param intrinsic_light_curve: reserved/rarely-used passthrough key; the
+         actual per-draw mechanism for supplying a library of intrinsic light
+         curves to sample from is ``input_agn_bounds_dict["intrinsic_light_curve"]``
+         (a list), not this key. Leave as ``None`` unless you specifically know you
+         need it.
+        :type intrinsic_light_curve: object or None
         """
 
-        kwargs.setdefault("allow_more_source_dict", True)
         super().__init__(
             extended_source=False,
             point_source=True,
@@ -72,6 +136,16 @@ class Quasar(SourceBase):
         self._agn_driving_kwargs_variability = agn_driving_kwargs_variability
         self.input_agn_bounds_dict = input_agn_bounds_dict
         self._kwargs_variability = kwargs_variability
+        self._black_hole_mass_exponent = black_hole_mass_exponent
+        self._black_hole_spin = black_hole_spin
+        self._inclination_angle = inclination_angle
+        self._r_out = r_out
+        self._r_resolution = r_resolution
+        self._eddington_ratio = eddington_ratio
+        self._accretion_disk = accretion_disk
+        self._corona_height = corona_height
+        self._driving_variability_model = driving_variability_model
+        self._intrinsic_light_curve = intrinsic_light_curve
         if kwargs_variability_model is None:
             self._variability_computed = False
         else:
@@ -89,8 +163,26 @@ class Quasar(SourceBase):
                 "provide a suitable astropy cosmology."
             )
         else:
-            # Pull the agn kwarg dict out of the kwargs_variability dict
-            agn_kwarg_dict = extract_agn_kwargs_from_source_dict(self.source_dict)
+            # Build the AGN disk-physics kwarg dict from the explicit constructor
+            # parameters, omitting any left as None so RandomAgn's random-fill
+            # behavior (see agn.py) kicks in for those -- a key present with value
+            # None would suppress that random-fill instead of triggering it.
+            agn_kwarg_dict = {
+                key: value
+                for key, value in {
+                    "black_hole_mass_exponent": self._black_hole_mass_exponent,
+                    "black_hole_spin": self._black_hole_spin,
+                    "inclination_angle": self._inclination_angle,
+                    "r_out": self._r_out,
+                    "r_resolution": self._r_resolution,
+                    "eddington_ratio": self._eddington_ratio,
+                    "accretion_disk": self._accretion_disk,
+                    "corona_height": self._corona_height,
+                    "driving_variability_model": self._driving_variability_model,
+                    "intrinsic_light_curve": self._intrinsic_light_curve,
+                }.items()
+                if value is not None
+            }
 
             # If no other band and magnitude is given, populate with
             # the assumed point source magnitude column
@@ -245,21 +337,3 @@ def add_mean_mag_to_source_table(sourcedict, mean_mags, band_list):
         _source_dict[name] = mean_mags[i]
 
     return _source_dict
-
-
-def extract_agn_kwargs_from_source_dict(source_dict):
-    """This extracts all AGN related parameters from a source_dict Table and
-    constructs a compact dictionary from them to pass into the agn class.
-
-    :param source_dict: Astropy Table with columns representing all
-        information of the source.
-    :return: Compact dict object containing key+value pairs of AGN
-        parameters.
-    """
-
-    # column_names = source_dict.colnames
-    agn_kwarg_dict = {}
-    for key in _AGN_VARIABILITY_KEYS:
-        if key in source_dict:
-            agn_kwarg_dict[key] = source_dict[key]  # .data[0]
-    return agn_kwarg_dict

--- a/slsim/Sources/SourceTypes/quasar.py
+++ b/slsim/Sources/SourceTypes/quasar.py
@@ -41,19 +41,25 @@ class Quasar(SourceBase):
     ):
         """
 
+        AGN accretion-disk parameters below (all optional). Any left as ``None`` are
+        drawn randomly by :func:`~slsim.Sources.SourceVariability.agn.RandomAgn` from
+        ``agn_bounds_dict`` (or ``input_agn_bounds_dict`` if provided) the first time
+        the AGN model is needed (on first access of ``.light_curve`` or
+        ``update_microlensing_kwargs_source_morphology``) -- this is a deliberate
+        generative feature (population diversity), not a fallback to guard against.
+        See :mod:`slsim.Sources.SourceVariability.agn` for the sampling distributions.
+
         :param lightcurve_time: time array for lightcurve in unit of days,
          defined in the rest (source) frame relative to time_zero_point (see
          Source._image_to_source_time_translation()). The AGN reprocessing response
          function is defined by the disk's physical light-crossing time, which is
          redshift-independent, so this is in rest-frame.
         :type lightcurve_time: array
-        :param source_dict: Source properties. May be a dictionary or an Astropy table.
-         This dict or table should contain atleast redshift and i-band magnitude.
-         eg: {"z": 0.8, "ps_mag_i": 22}
-        :type source_dict: dict or astropy.table.Table
         :param cosmo: astropy.cosmology instance
-        :param kwargs: dictionary of keyword arguments for a supernova. It sould contain
-          following keywords:
+        :param kwargs: required per-object catalog data (dict or one row of an
+         Astropy table), passed through to `SourceBase`. Must contain at least
+         redshift (``z``) and i-band magnitude (``ps_mag_i``).
+         eg: {"z": 0.8, "ps_mag_i": 22}
         :param variability_model: keyword for variability model to be used. This is an
             input for the Variability class.
         :type variability_model: str
@@ -63,15 +69,6 @@ class Quasar(SourceBase):
             a dictionary and this dict should be passed to the Variability class.
         :type kwargs_variability: list of str
         :param kwargs_variability_model: Pre-computed variabilities for each band (default=None)
-
-        AGN accretion-disk parameters (all optional). Any left as ``None`` are drawn
-        randomly by :class:`~slsim.Sources.SourceVariability.agn.RandomAgn` from
-        ``agn_bounds_dict`` (or ``input_agn_bounds_dict`` if provided) the first time
-        the AGN model is needed (on first access of ``.light_curve`` or
-        ``update_microlensing_kwargs_source_morphology``) -- this is a deliberate
-        generative feature (population diversity), not a fallback to guard against.
-        See :mod:`slsim.Sources.SourceVariability.agn` for the sampling distributions.
-
         :param black_hole_mass_exponent: mass exponent of the SMBH,
          log10(M_BH/M_sun). If ``None``, drawn from
          ``agn_bounds_dict["black_hole_mass_exponent_bounds"]``.

--- a/slsim/Sources/SourceTypes/source_base.py
+++ b/slsim/Sources/SourceTypes/source_base.py
@@ -4,19 +4,6 @@ from slsim.Util import param_util
 from slsim.Sources.SourceVariability.variability import Variability
 
 _SUPPORTED_KEYS = ["M", "coeff", "physical_size", "ellipticity", "phi_G", "MJD"]
-# TODO: find a better way not to store these keywords in the SourceBase class for better stability
-_AGN_VARIABILITY_KEYS = [
-    "r_out",
-    "r_resolution",
-    "corona_height",
-    "inclination_angle",
-    "black_hole_mass_exponent",
-    "black_hole_spin",
-    "intrinsic_light_curve",
-    "eddington_ratio",
-    "driving_variability_model",
-    "accretion_disk",
-]
 
 
 class SourceBase(ABC):
@@ -108,13 +95,13 @@ class SourceBase(ABC):
             for key in self.source_dict:
                 if key.startswith("ps_mag_") or key.startswith("mag_"):
                     pass
-                elif key in _SUPPORTED_KEYS or key in _AGN_VARIABILITY_KEYS:
+                elif key in _SUPPORTED_KEYS:
                     pass
                 else:
                     raise ValueError(
                         "Dictionary in Source class has invalid arguments. "
                         "Key %s is not part of ps_mag_<band> and mag_<band> or the supported keys %s."
-                        % (key, _SUPPORTED_KEYS + _AGN_VARIABILITY_KEYS)
+                        % (key, _SUPPORTED_KEYS)
                     )
 
         self._variability_bands = (

--- a/slsim/Sources/SourceTypes/source_base.py
+++ b/slsim/Sources/SourceTypes/source_base.py
@@ -63,8 +63,7 @@ class SourceBase(ABC):
         :param vel_disp: velocity dispersion [km/s]
         :type vel_disp: float or None
         :param kwargs: ps_mag_<band> keyword arguments and mag_<band> to store magnitudes for different bands
-        :type kwargs: dict
-        :type source_dict: dict or astropy.table.Table
+        :type kwargs: dict or astropy.table.Table
         :param allow_more_source_dict: if True, will not check for consistency of the dictionary with what is required.
          This is due to Extended+Point source models
         :type allow_more_source_dict: bool

--- a/slsim/Sources/SourceTypes/supernova_event.py
+++ b/slsim/Sources/SourceTypes/supernova_event.py
@@ -27,6 +27,20 @@ class SupernovaEvent(SourceBase):
         """# TODO: is there a specific variability model needed for this class,
         if so, we should set it directly.
 
+        Parameters fall into two categories:
+
+        - **Required per-object catalog data** (passed via ``kwargs``/``source_dict``,
+          typically one row of a catalog Table): at minimum ``z`` (redshift), plus
+          ``ra_off``/``dec_off`` if a host galaxy is present. See ``kwargs`` below.
+        - **Population-level config** (the explicit named arguments below --
+          ``sn_type``, ``sn_absolute_mag_band``, ``sn_absolute_zpsys``,
+          ``lightcurve_time``, ``variability_model``, ``sn_modeldir``,
+          ``kwargs_variability``): normally the same value for every draw, but any
+          of these may be overridden on a per-object basis by including a
+          same-named column in the input catalog (see `PointSources`/
+          `PointPlusExtendedSources`, which merge population-level config with the
+          per-object catalog row, catalog value taking precedence).
+
         :param sn_type: Supernova type (Ia, Ib, Ic, IIP, etc.)
             :type sn_type: str
         :param variability_model: keyword for variability model to be used. This is an
@@ -60,10 +74,10 @@ class SupernovaEvent(SourceBase):
          eg: {"z": 0.8, "ra_off": 0.001, "dec_off": 0.005}
         :type source_dict: dict or astropy.table.Table
         :param cosmo: astropy.cosmology instance
-        :param kwargs: dictionary of keyword arguments for a supernova for SourceBase() class.
-         May be a dictionary or an Astropy table.
-         This table or dict should contain atleast redshift of a supernova, offset from
-         the host if host galaxy is available.
+        :param kwargs: required per-object catalog data (dict or one row of an
+         Astropy table), passed through to `SourceBase`. Must contain at least
+         redshift (``z``); include ``ra_off``/``dec_off`` (offset from host galaxy
+         center, in arcsec) if a host galaxy is available.
          eg: {"z": 0.8, "ra_off": 0.001, "dec_off": 0.005}
         """
         if name is None:

--- a/slsim/Sources/SourceTypes/supernova_event.py
+++ b/slsim/Sources/SourceTypes/supernova_event.py
@@ -42,13 +42,13 @@ class SupernovaEvent(SourceBase):
           per-object catalog row, catalog value taking precedence).
 
         :param sn_type: Supernova type (Ia, Ib, Ic, IIP, etc.)
-            :type sn_type: str
+        :type sn_type: str
         :param variability_model: keyword for variability model to be used. This is an
             input for the Variability class.
-            :type variability_model: str
+        :type variability_model: str
         :param kwargs_variability: Dictionary with bands as strings, each containing a dictionary for a
          Variability() class input configurations for point source variability
-        :type kwargs_variability_model: dict of dict or None
+        :type kwargs_variability: dict of dict or None
         :param sn_absolute_mag_band: Band used to normalize to absolute magnitude
         :type sn_absolute_mag_band: str or `~sncosmo.Bandpass`
         :param sn_absolute_zpsys: Optional, AB or Vega (AB default)
@@ -68,11 +68,6 @@ class SupernovaEvent(SourceBase):
             For more detail, please look at the documentation of RandomizedSupernovae
             class.
         :type sn_modeldir: str
-        :param source_dict: Source properties. May be a dictionary or an Astropy table.
-         This table or dict should contain at least redshift of a supernova, offset from
-         the host if host galaxy is available.
-         eg: {"z": 0.8, "ra_off": 0.001, "dec_off": 0.005}
-        :type source_dict: dict or astropy.table.Table
         :param cosmo: astropy.cosmology instance
         :param kwargs: required per-object catalog data (dict or one row of an
          Astropy table), passed through to `SourceBase`. Must contain at least

--- a/tests/test_Sources/test_SourcePopulation/test_point_plus_extended_sources.py
+++ b/tests/test_Sources/test_SourcePopulation/test_point_plus_extended_sources.py
@@ -49,7 +49,8 @@ class TestPointPlusExtendedSources(object):
         assert point_plus_extended_sources2 is None
 
     def test_catalog_overrides_joint_kwargs_on_collision(self):
-        """A catalog column should override a same-named joint kwarg, not crash."""
+        """A catalog column should override a same-named joint kwarg, not
+        crash."""
         sky_area = Quantity(value=0.1, unit="deg2")
         catalog = self.source_list.copy()
         catalog["black_hole_mass_exponent"] = 9.0

--- a/tests/test_Sources/test_SourcePopulation/test_point_plus_extended_sources.py
+++ b/tests/test_Sources/test_SourcePopulation/test_point_plus_extended_sources.py
@@ -48,6 +48,28 @@ class TestPointPlusExtendedSources(object):
         point_plus_extended_sources2 = self.pe_source.draw_source(z_max=-1)
         assert point_plus_extended_sources2 is None
 
+    def test_catalog_overrides_joint_kwargs_on_collision(self):
+        """A catalog column should override a same-named joint kwarg, not crash."""
+        sky_area = Quantity(value=0.1, unit="deg2")
+        catalog = self.source_list.copy()
+        catalog["black_hole_mass_exponent"] = 9.0
+        kwargs = {
+            "variability_model": "light_curve",
+            "kwargs_variability": None,
+            "black_hole_mass_exponent": 7.0,
+        }
+        pe_source = PointPlusExtendedSources(
+            point_plus_extended_sources_list=catalog,
+            kwargs_cut=None,
+            cosmo=self.cosmo,
+            sky_area=sky_area,
+            point_source_type="quasar",
+            extended_source_type="single_sersic",
+            joint_point_source_kwargs=kwargs,
+        )
+        source = pe_source.draw_source()
+        assert source.point_source._black_hole_mass_exponent == 9.0
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_Sources/test_SourcePopulation/test_point_sources.py
+++ b/tests/test_Sources/test_SourcePopulation/test_point_sources.py
@@ -61,7 +61,8 @@ class TestPointSources(object):
         assert isinstance(point_source, Source)
 
     def test_catalog_overrides_joint_kwargs_on_collision(self):
-        """A catalog column should override a same-named joint kwarg, and should not crash."""
+        """A catalog column should override a same-named joint kwarg, and
+        should not crash."""
         sky_area = Quantity(value=0.1, unit="deg2")
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         catalog = self.quasar_list.copy()

--- a/tests/test_Sources/test_SourcePopulation/test_point_sources.py
+++ b/tests/test_Sources/test_SourcePopulation/test_point_sources.py
@@ -59,3 +59,25 @@ class TestPointSources(object):
         )
         point_source = point_sources.draw_source()
         assert isinstance(point_source, Source)
+
+    def test_catalog_overrides_joint_kwargs_on_collision(self):
+        """A catalog column should override a same-named joint kwarg, and should not crash."""
+        sky_area = Quantity(value=0.1, unit="deg2")
+        cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        catalog = self.quasar_list.copy()
+        catalog["black_hole_mass_exponent"] = 9.0
+        kwargs = {
+            "variability_model": "light_curve",
+            "kwargs_variability": None,
+            "black_hole_mass_exponent": 7.0,
+        }
+        point_sources = PointSources(
+            point_source_list=catalog,
+            cosmo=cosmo,
+            sky_area=sky_area,
+            kwargs_cut={},
+            point_source_type="quasar",
+            joint_point_source_kwargs=kwargs,
+        )
+        source = point_sources.draw_source()
+        assert source.point_source._black_hole_mass_exponent == 9.0

--- a/tests/test_Sources/test_SourceTypes/test_quasar.py
+++ b/tests/test_Sources/test_SourceTypes/test_quasar.py
@@ -1,4 +1,4 @@
-from slsim.Sources.SourceTypes.quasar import Quasar, extract_agn_kwargs_from_source_dict
+from slsim.Sources.SourceTypes.quasar import Quasar
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -202,21 +202,30 @@ class TestQuasar:
         assert "eddington_ratio" in updated_kwargs
         assert updated_kwargs["eddington_ratio"] == 0.1
 
+    def test_unset_agn_params_get_random_fill(self):
+        """Unset AGN params (None) must still be randomly filled, not left as None."""
+        updated_kwargs = (
+            self.source_agn_params.update_microlensing_kwargs_source_morphology({})
+        )
 
-def test_extract_agn_kwargs_from_source_dict():
-    source_dict = {
-        "z": 0.8,
-        "ps_mag_i": 20,
-        "random_seed": 42,
-        "black_hole_mass_exponent": 8.0,
-        "eddington_ratio": 0.5,
-    }
+        # explicitly-set values preserved
+        assert updated_kwargs["black_hole_mass_exponent"] == 8.5
+        assert updated_kwargs["eddington_ratio"] == 0.1
 
-    agn_kwargs = extract_agn_kwargs_from_source_dict(source_dict=source_dict)
-    assert "black_hole_mass_exponent" in agn_kwargs
-    assert "eddington_ratio" in agn_kwargs
-    assert agn_kwargs["black_hole_mass_exponent"] == 8.0
-    assert agn_kwargs["eddington_ratio"] == 0.5
+        # unset values were randomly filled within their bounds, not left as None
+        kwargs_model = self.source_agn_params.agn_class.kwargs_model
+        assert kwargs_model["black_hole_spin"] is not None
+        assert -0.997 <= kwargs_model["black_hole_spin"] <= 0.997
+        assert kwargs_model["inclination_angle"] is not None
+        assert 0 <= kwargs_model["inclination_angle"] <= 90
+        assert kwargs_model["r_out"] is not None
+        assert kwargs_model["accretion_disk"] == "thin_disk"
+
+
+def test_unrecognized_kwarg_raises_value_error():
+    """Misspelled/unrecognized keywords must raise, not be silently absorbed."""
+    with pytest.raises(ValueError):
+        Quasar(z=0.8, ps_mag_i=20, black_hole_mass_exponet=8.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_Sources/test_SourceTypes/test_quasar.py
+++ b/tests/test_Sources/test_SourceTypes/test_quasar.py
@@ -203,7 +203,8 @@ class TestQuasar:
         assert updated_kwargs["eddington_ratio"] == 0.1
 
     def test_unset_agn_params_get_random_fill(self):
-        """Unset AGN params (None) must still be randomly filled, not left as None."""
+        """Unset AGN params (None) must still be randomly filled, not left as
+        None."""
         updated_kwargs = (
             self.source_agn_params.update_microlensing_kwargs_source_morphology({})
         )
@@ -223,7 +224,8 @@ class TestQuasar:
 
 
 def test_unrecognized_kwarg_raises_value_error():
-    """Misspelled/unrecognized keywords must raise, not be silently absorbed."""
+    """Misspelled/unrecognized keywords must raise, not be silently
+    absorbed."""
     with pytest.raises(ValueError):
         Quasar(z=0.8, ps_mag_i=20, black_hole_mass_exponet=8.0)
 


### PR DESCRIPTION
Trying to expose the functionality of point source classes in a consistent manner across all source types. This addresses the issue [#456 ](https://github.com/LSST-strong-lensing/slsim/issues/456)