### PR TITLE
minor fix to support latest numpy

### DIFF
--- a/slsim/Deflectors/DeflectorPopulation/deflectors_base.py
+++ b/slsim/Deflectors/DeflectorPopulation/deflectors_base.py
@@ -23,6 +23,7 @@ class DeflectorsBase(Galaxies):
         light_type="single_sersic",
         kwargs_mass2light=None,
         catalog_type=None,
+        sis_convention=True,
     ):
         """
 
@@ -47,6 +48,11 @@ class DeflectorsBase(Galaxies):
          size of the galaxy in arcsec and specify catalog_type as None. Otherwise, by
          default, this class considers deflector catalog is generated using skypy
          pipeline.
+        :param sis_convention: if True, the Einstein radius of an EPL deflector is
+         normalized with the SIS convention. Only relevant for mass_type="EPL" with
+         gamma_pl != 2. The non-SIS normalization solves the spherical Jeans equation
+         for every deflector and is orders of magnitude slower.
+        :type sis_convention: bool
         """
         super().__init__(
             galaxy_list=deflector_table,
@@ -65,6 +71,7 @@ class DeflectorsBase(Galaxies):
             kwargs_mass2light = {}
         self._kwargs_mass2light = kwargs_mass2light
         self._gamma_pl = gamma_pl
+        self._sis_convention = sis_convention
         self._vel_disp_from_stellar_mass = None
         # Will be overwriten by interpolation function deriving velocity dispersion from stellar mass
 
@@ -124,6 +131,7 @@ class DeflectorsBase(Galaxies):
         if self.mass_type in ["EPL"]:
             if self._gamma_pl is not None:
                 kwargs_mass["gamma_pl"] = _gamma_pl(self._gamma_pl)
+            kwargs_mass["sis_convention"] = self._sis_convention
         if (
             "vel_disp" not in kwargs_mass
             and "stellar_mass" in kwargs_source

--- a/slsim/Deflectors/DeflectorPopulation/galaxy_deflectors.py
+++ b/slsim/Deflectors/DeflectorPopulation/galaxy_deflectors.py
@@ -26,6 +26,7 @@ class GalaxyDeflectors(DeflectorsBase):
         catalog_type="skypy",
         mass_type="EPL",
         light_type="single_sersic",
+        sis_convention=True,
     ):
         """
         :param red_galaxy_list: list of dictionary with elliptical galaxy
@@ -56,6 +57,11 @@ class GalaxyDeflectors(DeflectorsBase):
          default, this class considers deflector catalog is generated using skypy
          pipeline.
         :type catalog_type: str. "skypy" or None.
+        :param sis_convention: if True, the Einstein radius of an EPL deflector is
+         normalized with the SIS convention. Only relevant for mass_type="EPL" with
+         gamma_pl != 2. The non-SIS normalization solves the spherical Jeans equation
+         for every deflector and is orders of magnitude slower.
+        :type sis_convention: bool
         """
         red_column_names = red_galaxy_list.colnames
         if "galaxy_type" not in red_column_names:
@@ -87,4 +93,5 @@ class GalaxyDeflectors(DeflectorsBase):
             catalog_type=catalog_type,
             mass_type=mass_type,
             light_type=light_type,
+            sis_convention=sis_convention,
         )

--- a/slsim/Deflectors/MassLightConnection/velocity_dispersion.py
+++ b/slsim/Deflectors/MassLightConnection/velocity_dispersion.py
@@ -717,7 +717,10 @@ def schechter_velocity_dispersion_function(
     v_sample = np.interp(u, cdf, v)
     return v_sample
 
-
+# TODO: abundance matching needs to be power law slope aware.
+# Currently pl-slope is randomly assigned to each galaxy and only the M_star and sigma_v are matched. 
+# This is not correct as the pl-slope and sigma_v are correlated. 
+# Need to implement a more sophisticated abundance matching that takes into account the pl-slope and sigma_v correlation.
 def vel_disp_abundance_matching(galaxy_list, z_max, sky_area, cosmo):
     """Calculates the velocity dispersion from the steller mass. The routine
     uses abundance matching between stellar mass and velocity dispersion taking
@@ -753,7 +756,7 @@ def vel_disp_abundance_matching(galaxy_list, z_max, sky_area, cosmo):
     # sort velocity dispersion, largest values first
     vel_disp_list = np.flip(np.sort(vel_disp_list))
     num_vel_disp = len(vel_disp_list)
-    # abundance match velocity dispersion with elliptical galaxy catalogue
+
     # abundance match velocity dispersion with elliptical galaxy catalogue
     if num_vel_disp >= num_select:
         galaxy_list_zmax["vel_disp"] = vel_disp_list[:num_select]

--- a/slsim/Deflectors/MassLightConnection/velocity_dispersion.py
+++ b/slsim/Deflectors/MassLightConnection/velocity_dispersion.py
@@ -717,9 +717,10 @@ def schechter_velocity_dispersion_function(
     v_sample = np.interp(u, cdf, v)
     return v_sample
 
+
 # TODO: abundance matching needs to be power law slope aware.
-# Currently pl-slope is randomly assigned to each galaxy and only the M_star and sigma_v are matched. 
-# This is not correct as the pl-slope and sigma_v are correlated. 
+# Currently pl-slope is randomly assigned to each galaxy and only the M_star and sigma_v are matched.
+# This is not correct as the pl-slope and sigma_v are correlated.
 # Need to implement a more sophisticated abundance matching that takes into account the pl-slope and sigma_v correlation.
 def vel_disp_abundance_matching(galaxy_list, z_max, sky_area, cosmo):
     """Calculates the velocity dispersion from the steller mass. The routine

--- a/slsim/Deflectors/deflector.py
+++ b/slsim/Deflectors/deflector.py
@@ -46,6 +46,9 @@ class Deflector(object):
         )
         self.mass = Mass(light=self.light, **kwargs_mass)
 
+        self._kwargs_mass = kwargs_mass
+        self._kwargs_light = kwargs_light
+
     @property
     def name(self):
         """Takes name of light model.

--- a/slsim/Sources/SourceCatalogues/QuasarCatalog/quasar_pop.py
+++ b/slsim/Sources/SourceCatalogues/QuasarCatalog/quasar_pop.py
@@ -203,6 +203,8 @@ class QuasarRate(object):
         :return: dPhi_dM value in the unit of comoving volume.
         :rtype: float or np.ndarray :unit: mag^-1 Mpc^-3
         """
+        return_scalar = np.ndim(M) == 0
+
         M = np.atleast_1d(M)
         z_value = np.atleast_1d(z_value)
 
@@ -226,7 +228,7 @@ class QuasarRate(object):
             where=denominator_dphi_dm != 0,
         )
 
-        return term1
+        return term1 if not return_scalar else term1.item()
 
     def convert_magnitude(self, magnitude, z, conversion="apparent_to_absolute"):
         """Converts between apparent and absolute magnitudes using


### PR DESCRIPTION
With numpy 2.5.1 I was experiencing issues but I see that in requirements.txt the numpy version is set to < 2.4.0 so perhaps this is not needed right now but flagging this here just in case. Will add a fallback for backwards compatibility with numpy < 2.4

This PR also makes the `sis_convention=True` as the default option and allows the user to modify it if they want to via the `GalaxyDeflectors` class.

Have also flagged that abundance matching needs to be updated such that it is pl-slope aware in addition to M* and sigma*